### PR TITLE
Rename tamp_compressor_compress_poll to tamp_compressor_poll.

### DIFF
--- a/docs/source/c_library.rst
+++ b/docs/source/c_library.rst
@@ -96,7 +96,7 @@ To use these 2 functions effectively, loop over calling ``tamp_compressor_sink``
         {
             // Perform 1 compression cycle on internal input buffer
             size_t chunk_output_written_size;
-            res = tamp_compressor_compress_poll(compressor, output, output_size, &chunk_output_written_size);
+            res = tamp_compressor_poll(compressor, output, output_size, &chunk_output_written_size);
             output += chunk_output_written_size;
             output_size -= chunk_output_written_size;
             assert(res == TAMP_OK);
@@ -118,7 +118,7 @@ The remaining ``"er the lazy dog"`` is still in the compressor's internal buffer
 
 To flush the remaining data, use ``tamp_compressor_flush`` that performs the following actions:
 
-1. Repeatedly call ``tamp_compressor_compress_poll`` until the 16-byte internal input buffer is empty.
+1. Repeatedly call ``tamp_compressor_poll`` until the 16-byte internal input buffer is empty.
 
 2. Flush the output buffer. If ``write_token=true``, then the special ``FLUSH`` token will be appended if padding was required.
 

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -135,7 +135,7 @@ tamp_res tamp_compressor_init(TampCompressor *compressor, const TampConf *conf, 
 }
 
 
-tamp_res tamp_compressor_compress_poll(TampCompressor *compressor, unsigned char *output, size_t output_size, size_t *output_written_size){
+tamp_res tamp_compressor_poll(TampCompressor *compressor, unsigned char *output, size_t output_size, size_t *output_written_size){
     tamp_res res;
     const uint16_t window_mask = (1 << compressor->conf_window) - 1;
     size_t output_written_size_proxy;
@@ -247,7 +247,7 @@ tamp_res tamp_compressor_compress(
         if(TAMP_LIKELY(compressor->input_size == sizeof(compressor->input))){
             // Input buffer is full and ready to start compressing.
             size_t chunk_output_written_size;
-            res = tamp_compressor_compress_poll(compressor, output, output_size, &chunk_output_written_size);
+            res = tamp_compressor_poll(compressor, output, output_size, &chunk_output_written_size);
             output += chunk_output_written_size;
             output_size -= chunk_output_written_size;
             (*output_written_size) += chunk_output_written_size;
@@ -275,7 +275,7 @@ tamp_res tamp_compressor_flush(
 
     while(compressor->input_size){
         // Compress the remainder of the input buffer.
-        res = tamp_compressor_compress_poll(compressor, output, output_size, &chunk_output_written_size);
+        res = tamp_compressor_poll(compressor, output, output_size, &chunk_output_written_size);
         (*output_written_size) += chunk_output_written_size;
         if(TAMP_UNLIKELY(res != TAMP_OK))
             return res;

--- a/tamp/_c_src/tamp/compressor.h
+++ b/tamp/_c_src/tamp/compressor.h
@@ -98,7 +98,7 @@ void tamp_compressor_sink(
  *
  * @return Tamp Status Code. Can return TAMP_OK, TAMP_OUTPUT_FULL, or TAMP_EXCESS_BITS.
  */
-tamp_res tamp_compressor_compress_poll(
+tamp_res tamp_compressor_poll(
         TampCompressor *compressor,
         unsigned char *output,
         size_t output_size,

--- a/tamp/ctamp.pxd
+++ b/tamp/ctamp.pxd
@@ -35,7 +35,7 @@ cdef extern from "tamp/compressor.h":
             size_t *consumed_size
             );
 
-    tamp_res tamp_compressor_compress_poll(
+    tamp_res tamp_compressor_poll(
             TampCompressor *compressor,
             unsigned char *output,
             size_t output_size,


### PR DESCRIPTION
This is a breaking API change. The previous name was an erroneous oversight. Super easy change for anyone currently using the library.