### PR TITLE
Add option to automatically reset task WDT during compression.

### DIFF
--- a/espidf/Kconfig
+++ b/espidf/Kconfig
@@ -8,4 +8,11 @@ menu "tamp"
 		On ESP32-S3, this also enables use of the chip's SIMD instructions ("PIE")
 		for increased speed.
 
+	config TAMP_ESP32_AUTO_RESET_TASK_WDT
+	bool "Automatically reset task watch dog timer."
+	depends on TAMP_ESP32
+	default n
+	help
+		Automatically resets the task watchdog-timer after every compression cycle.
+
 endmenu

--- a/espidf/compressor_esp32.cpp
+++ b/espidf/compressor_esp32.cpp
@@ -9,6 +9,10 @@
 #include <stdbool.h>
 #include <cstring>
 
+#if TAMP_ESP32_AUTO_RESET_TASK_WDT
+#include "esp_task_wdt.h"
+#endif
+
 #include "private/tamp_search.hpp"
 #include "private/copyutil.hpp"
 
@@ -119,6 +123,10 @@ void find_best_match(
         uint8_t *match_size
         ){
     tamp::byte_span out {};
+
+#if TAMP_ESP32_AUTO_RESET_TASK_WDT
+    esp_task_wdt_reset();
+#endif
 
     if(TAMP_LIKELY(compressor->input_size >= compressor->min_pattern_size))
     {


### PR DESCRIPTION
Disabled by default, as the caller should be aware that the WDT is being reset.