### PR TITLE
add `tamp_compressor_full` to the C api.

### DIFF
--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -206,7 +206,7 @@ void tamp_compressor_sink(
         consumed_size = &consumed_size_proxy;
 
     for(size_t i=0; i < input_size; i++){
-        if(TAMP_UNLIKELY(compressor->input_size == sizeof(compressor->input)))
+        if(TAMP_UNLIKELY(tamp_compressor_full(compressor)))
             break;
         compressor->input[input_add(compressor->input_size)] = input[i];
         compressor->input_size += 1;
@@ -248,7 +248,7 @@ tamp_res tamp_compressor_compress_cb(
             input_size -= consumed;
             (*input_consumed_size) += consumed;
         }
-        if(TAMP_LIKELY(compressor->input_size == sizeof(compressor->input))){
+        if(TAMP_LIKELY(tamp_compressor_full(compressor))){
             // Input buffer is full and ready to start compressing.
             size_t chunk_output_written_size;
             res = tamp_compressor_poll(compressor, output, output_size, &chunk_output_written_size);

--- a/tamp/_c_src/tamp/compressor.h
+++ b/tamp/_c_src/tamp/compressor.h
@@ -123,6 +123,17 @@ tamp_res tamp_compressor_poll(
 #define tamp_compressor_compress_poll tamp_compressor_poll
 
 /**
+ * @brief Check if the compressor's input buffer is full.
+ *
+ * @param[in] compressor TampCompressor object to check.
+ *
+ * @return true if the compressor is full, false otherwise.
+ */
+TAMP_ALWAYS_INLINE bool tamp_compressor_full(TampCompressor *compressor) {
+    return compressor->input_size == sizeof(compressor->input);
+}
+
+/**
  * @brief Completely flush the internal bit buffer. Makes output "complete".
  *
  * The following table contains the most number of bytes that could be flushed in a worst-case scenario:


### PR DESCRIPTION
Addresses shortcoming mentioned in #208. Developer shouldn't be reaching into TampCompressor internals to figure out if the input buffer is full.