### PR TITLE
c: decompressor: Force integer promotion type for bit_buffer

### DIFF
--- a/tamp/_c_src/tamp/decompressor.c
+++ b/tamp/_c_src/tamp/decompressor.c
@@ -131,8 +131,9 @@ tamp_res tamp_decompressor_decompress_cb(TampDecompressor *decompressor, unsigne
     while (input != input_end || decompressor->bit_buffer_pos) {
         // Populate the bit buffer
         while (input != input_end && decompressor->bit_buffer_pos <= 24) {
+            uint32_t t = *input;
             decompressor->bit_buffer_pos += 8;
-            decompressor->bit_buffer |= *input << (32 - decompressor->bit_buffer_pos);
+            decompressor->bit_buffer |= t << (32 - decompressor->bit_buffer_pos);
             input++;
             (*input_consumed_size)++;
         }


### PR DESCRIPTION
C does automatic integer promotion when performing calculations with smaller types (like unsigned integers). But it only guarantees the size (and type) of an int. But the  bit_buffer is explicitly an uint32_t. It can therefore be that an int is not 32 bit (depending on the target architecture).

Also, shifting a signed integer (affecting the sign bit) is undefined behavior in C. Compilers like GCC can therefore perform optimizations which break the expected behavior. The shifted type must therefore be forced to unsigned.

This can be seen when enabling the undefined behavior sanitizer of GCC/clang:

    decompressor.c:135:43: runtime error: left shift of 131 by 24 places cannot be represented in type 'int'

Fixes: 85ef612bd424 ("decompressor progress")