### PR TITLE
C++17 compatibility patch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
       - id: clang-format
         types_or: [c, c++]
         args: ['-style=file', '-i']
+        exclude: ^espidf/tamp/private/tamp_search\.hpp$
 
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5

--- a/espidf/tamp/CMakeLists.txt
+++ b/espidf/tamp/CMakeLists.txt
@@ -7,7 +7,13 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_CXX_STANDARD 20)
+if(IDF_VER_MAJOR EQUAL 4 AND IDF_VER_MINOR LESS 5)
+    # ESP-IDF 4.0 -> 4.4: default compiler is C++11; enable C++17 safely
+    set(CMAKE_CXX_STANDARD 17)
+else()
+    # ESP-IDF >= 4.5 or 5.x: use C++20
+    set(CMAKE_CXX_STANDARD 20)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 

--- a/espidf/tamp/private/copyutil.hpp
+++ b/espidf/tamp/private/copyutil.hpp
@@ -90,8 +90,8 @@ static constexpr uint32_t MSB = (1 << log2<N>());
  * @param len
  */
 template <uint32_t CEIL = 16>
-    requires(CEIL != 0 /* && (CEIL & (CEIL-1)) == 0 */)
 static inline void __attribute__((always_inline)) unrolled_cpy(void* dst, const void* src, std::size_t len) noexcept {
+    static_assert(CEIL != 0 /* && (CEIL & (CEIL-1)) == 0 */);
     if constexpr (CEIL > 32) {
         // You should probably be using std::memcpy...
         {
@@ -120,6 +120,10 @@ static inline void __attribute__((always_inline)) unrolled_cpy(void* dst, const 
             incptr<CEIL / 2>(src);
         }
         unrolled_cpy<CEIL / 2>(dst, src, len);
+    } else {
+        (void)dst;
+        (void)src;
+        (void)len;
     }
 }
 }  // namespace

--- a/espidf/tamp/private/tamp_search.hpp
+++ b/espidf/tamp/private/tamp_search.hpp
@@ -354,41 +354,41 @@ class Locator {
                 if constexpr (Arch::XTENSA && Arch::XT_LOOP) {
                     uint32_t tmp;
 
-                        asm("LOOPNEZ %[len], end_%="
-                            "\n"
-                            "L32I %[tmp], %[data], 0"
-                            "\n"
-                            "ADDI %[data], %[data], 1"
-                            "\n"  // Pipelining.
-                            "BEQ %[tmp], %[v], found_%="
-                            "\n"
-                            "end_%=:"
-                            "\n"
-                            "MOVI %[data], 1"
-                            "\n"  // Make result = 0 w/o a jump
-                            "found_%=:"
-                            "\n"
-                            "ADDI %[data], %[data], -1"
-                            "\n"
-                            "exit_%=:"
-                            : [tmp] "=&r"(tmp), [data] "+&r"(data)
-                            : [v] "r"(v), [len] "r"(dataLen - (sizeof(uint32_t) - 1)),
-                              "m"(*(const uint8_t(*)[dataLen])data));
+                    asm("LOOPNEZ %[len], end_%="
+                        "\n"
+                        "L32I %[tmp], %[data], 0"
+                        "\n"
+                        "ADDI %[data], %[data], 1"
+                        "\n"  // Pipelining.
+                        "BEQ %[tmp], %[v], found_%="
+                        "\n"
+                        "end_%=:"
+                        "\n"
+                        "MOVI %[data], 1"
+                        "\n"  // Make result = 0 w/o a jump
+                        "found_%=:"
+                        "\n"
+                        "ADDI %[data], %[data], -1"
+                        "\n"
+                        "exit_%=:"
+                        : [tmp] "=&r"(tmp), [data] "+&r"(data)
+                        : [v] "r"(v), [len] "r"(dataLen - (sizeof(uint32_t) - 1)),
+                          "m"(*(const uint8_t(*)[dataLen])data));
 
-                        return data;
+                    return data;
 
-                    } else {
-                        constexpr uint32_t LOOP_UNROLL_FACTOR = 8;
+                } else {
+                    constexpr uint32_t LOOP_UNROLL_FACTOR = 8;
 
-                        const uint8_t* const end_unrolled = data + multof<LOOP_UNROLL_FACTOR>(dataLen - (patLen - 1));
-                        while (data < end_unrolled && !unrolled_find<uint32_t, LOOP_UNROLL_FACTOR>(data, v)) TAMP_CPP_LIKELY {
-                            incptr<LOOP_UNROLL_FACTOR>(data);
-                        }
+                    const uint8_t* const end_unrolled = data + multof<LOOP_UNROLL_FACTOR>(dataLen - (patLen - 1));
+                    while (data < end_unrolled && !unrolled_find<uint32_t, LOOP_UNROLL_FACTOR>(data, v)) TAMP_CPP_LIKELY {
+                        incptr<LOOP_UNROLL_FACTOR>(data);
+                    }
 
-                        if (data >= end_unrolled) {
-                            // Nothing found so far.
-                            while (data < end && as<uint32_t>(data) != v) {
-                                incptr<1>(data);
+                    if (data >= end_unrolled) {
+                        // Nothing found so far.
+                        while (data < end && as<uint32_t>(data) != v) {
+                            incptr<1>(data);
                         }
                     }
                 }
@@ -526,15 +526,15 @@ class Locator {
                 if constexpr (Arch::XTENSA && Arch::XT_LOOP) {
                     uint32_t tmp = dataLen;
                     asm volatile(
-                            "LOOPNEZ %[tmp], end_%="
-                            "\n"
-                            "L8UI %[tmp], %[data], 0"
-                            "\n"
-                            "BEQ %[tmp], %[v], end_%="
-                            "\n"
-                            "ADDI %[data], %[data], 1"
-                            "\n"
-                            "end_%=:"
+                        "LOOPNEZ %[tmp], end_%="
+                        "\n"
+                        "L8UI %[tmp], %[data], 0"
+                        "\n"
+                        "BEQ %[tmp], %[v], end_%="
+                        "\n"
+                        "ADDI %[data], %[data], 1"
+                        "\n"
+                        "end_%=:"
                         : [tmp] "+r"(tmp), [data] "+r"(data)
                         : [v] "r"(v));
                 } else {

--- a/espidf/tamp/private/tamp_search.hpp
+++ b/espidf/tamp/private/tamp_search.hpp
@@ -29,11 +29,9 @@
 #include "tamp_arch.hpp"
 
 #if __cplusplus >= 202002L
-// #define TAMP_REQUIRES(...) requires(__VA_ARGS__)
 #define TAMP_CPP_LIKELY [[likely]]
 #define TAMP_CPP_UNLIKELY [[unlikely]]
 #else
-// #define TAMP_REQUIRES(...) /* nothing */
 #define TAMP_CPP_LIKELY
 #define TAMP_CPP_UNLIKELY
 #endif

--- a/espidf/tamp/private/tamp_search.hpp
+++ b/espidf/tamp/private/tamp_search.hpp
@@ -285,13 +285,12 @@ class Locator {
     template <typename T, uint32_t M, uint32_t N = 0>
     static bool __attribute__((always_inline)) unrolled_find(const uint8_t*& data, const uint32_t v) noexcept {
         if (as<T>(data + N) != v) TAMP_CPP_LIKELY {
-                if constexpr (N + 1 < M) {
-                    return unrolled_find<T, M, N + 1>(data, v);
-                } else {
-                    return false;
-                }
+            if constexpr (N + 1 < M) {
+                return unrolled_find<T, M, N + 1>(data, v);
+            } else {
+                return false;
             }
-        else {
+        } else {
             incptr<N>(data);
             return true;
         }
@@ -309,25 +308,23 @@ class Locator {
         static_assert(N < M);
         if constexpr (N % 2 == 0) {
             if ((as<uint32_t>(data + ((N / 2) * 2)) << 8) != vl) TAMP_CPP_LIKELY {
-                    if constexpr (N + 1 < M) {
-                        return unrolled_find_3<M, N + 1>(data, vl, vh);
-                    } else {
-                        return false;
-                    }
+                if constexpr (N + 1 < M) {
+                    return unrolled_find_3<M, N + 1>(data, vl, vh);
+                } else {
+                    return false;
                 }
-            else {
+            } else {
                 incptr<N>(data);
                 return true;
             }
         } else {
             if ((as<uint32_t>(data + ((N / 2) * 2)) >> 8) != vh) TAMP_CPP_LIKELY {
-                    if constexpr (N + 1 < M) {
-                        return unrolled_find_3<M, N + 1>(data, vl, vh);
-                    } else {
-                        return false;
-                    }
+                if constexpr (N + 1 < M) {
+                    return unrolled_find_3<M, N + 1>(data, vl, vh);
+                } else {
+                    return false;
                 }
-            else {
+            } else {
                 incptr<N>(data);
                 return true;
             }
@@ -352,10 +349,10 @@ class Locator {
 
         if (patLen > sizeof(uint16_t)) {
             if (patLen == sizeof(uint32_t)) TAMP_CPP_UNLIKELY {
-                    const uint32_t v = as<uint32_t>(pattern);
+                const uint32_t v = as<uint32_t>(pattern);
 
-                    if constexpr (Arch::XTENSA && Arch::XT_LOOP) {
-                        uint32_t tmp;
+                if constexpr (Arch::XTENSA && Arch::XT_LOOP) {
+                    uint32_t tmp;
 
                         asm("LOOPNEZ %[len], end_%="
                             "\n"
@@ -384,18 +381,18 @@ class Locator {
                         constexpr uint32_t LOOP_UNROLL_FACTOR = 8;
 
                         const uint8_t* const end_unrolled = data + multof<LOOP_UNROLL_FACTOR>(dataLen - (patLen - 1));
-                        while (data < end_unrolled && !unrolled_find<uint32_t, LOOP_UNROLL_FACTOR>(data, v))
-                            TAMP_CPP_LIKELY { incptr<LOOP_UNROLL_FACTOR>(data); }
+                        while (data < end_unrolled && !unrolled_find<uint32_t, LOOP_UNROLL_FACTOR>(data, v)) TAMP_CPP_LIKELY {
+                            incptr<LOOP_UNROLL_FACTOR>(data);
+                        }
 
                         if (data >= end_unrolled) {
                             // Nothing found so far.
                             while (data < end && as<uint32_t>(data) != v) {
                                 incptr<1>(data);
-                            }
                         }
                     }
                 }
-            else {
+            } else {
                 // assert patLen == 3
 
                 // Given a 24-bit value in a 32-bit variable V and 4 bytes (32 bits) loaded from memory
@@ -457,8 +454,8 @@ class Locator {
                     const uint8_t* const end_unrolled = data + multof<LOOP_UNROLL_FACTOR>(dataLen - (patLen - 1));
 
                     while (data < end_unrolled && !unrolled_find_3<LOOP_UNROLL_FACTOR>(data, vl, vh)) TAMP_CPP_LIKELY {
-                            incptr<LOOP_UNROLL_FACTOR>(data);
-                        }
+                        incptr<LOOP_UNROLL_FACTOR>(data);
+                    }
 
                     if (data >= end_unrolled) {
                         // Nothing found so far.
@@ -511,8 +508,9 @@ class Locator {
                     // Loop unrolled 8x.
                     const uint8_t* const end_unrolled = data + multof<LOOP_UNROLL_FACTOR>(dataLen - (patLen - 1));
 
-                    while (data < end_unrolled && !unrolled_find<uint16_t, LOOP_UNROLL_FACTOR>(data, v))
-                        TAMP_CPP_LIKELY { incptr<LOOP_UNROLL_FACTOR>(data); }
+                    while (data < end_unrolled && !unrolled_find<uint16_t, LOOP_UNROLL_FACTOR>(data, v)) TAMP_CPP_LIKELY {
+                        incptr<LOOP_UNROLL_FACTOR>(data);
+                    }
 
                     if (data >= end_unrolled) {
                         // Nothing found so far.
@@ -522,13 +520,12 @@ class Locator {
                     }
                 }
 
-            } else
-                TAMP_CPP_UNLIKELY {
-                    // assert patLen == 1
-                    const uint32_t v = as<uint8_t>(pattern);
-                    if constexpr (Arch::XTENSA && Arch::XT_LOOP) {
-                        uint32_t tmp = dataLen;
-                        asm volatile(
+            } else TAMP_CPP_UNLIKELY {
+                // assert patLen == 1
+                const uint32_t v = as<uint8_t>(pattern);
+                if constexpr (Arch::XTENSA && Arch::XT_LOOP) {
+                    uint32_t tmp = dataLen;
+                    asm volatile(
                             "LOOPNEZ %[tmp], end_%="
                             "\n"
                             "L8UI %[tmp], %[data], 0"
@@ -538,14 +535,14 @@ class Locator {
                             "ADDI %[data], %[data], 1"
                             "\n"
                             "end_%=:"
-                            : [tmp] "+r"(tmp), [data] "+r"(data)
-                            : [v] "r"(v));
-                    } else {
-                        while (data < end && as<uint8_t>(data) != v) {
-                            incptr<1>(data);
-                        }
+                        : [tmp] "+r"(tmp), [data] "+r"(data)
+                        : [v] "r"(v));
+                } else {
+                    while (data < end && as<uint8_t>(data) != v) {
+                        incptr<1>(data);
                     }
                 }
+            }
         }
         return (data < end) ? data : nullptr;
     }
@@ -555,13 +552,12 @@ class Locator {
     static bool __attribute__((always_inline))
     unrolled_find_f_l(const uint8_t*& first, const uint8_t*& last, const uint32_t f, const uint32_t l) noexcept {
         if (f != as<uint32_t>(first + N) || l != as<uint32_t>(last + N)) TAMP_CPP_LIKELY {
-                if constexpr (N + 1 < M) {
-                    return unrolled_find_f_l<M, N + 1>(first, last, f, l);
-                } else {
-                    return false;
-                }
+            if constexpr (N + 1 < M) {
+                return unrolled_find_f_l<M, N + 1>(first, last, f, l);
+            } else {
+                return false;
             }
-        else {
+        } else {
             incptr<N>(first);
             incptr<N>(last);
             return true;
@@ -578,9 +574,8 @@ class Locator {
             const uint8_t* ff = find_pattern_short_scalar((const uint8_t*)&f, sizeof(uint32_t), fp, end - fp);
             if (ff) {
                 if (*(const uint32_t*)(ff + len) != l) TAMP_CPP_LIKELY {
-                        fp = ff + 1;
-                    }
-                else {
+                    fp = ff + 1;
+                } else {
                     first = ff;
                     last = ff + len;
                     return true;
@@ -637,11 +632,10 @@ class Locator {
             {
                 constexpr uint32_t LOOP_UNROLL_FACTOR = 8;
                 const uint8_t* const end_unrolled = first + multof<LOOP_UNROLL_FACTOR>(end - first);
-                while (first < end_unrolled && !unrolled_find_f_l<LOOP_UNROLL_FACTOR>(first, last, f, l))
-                    TAMP_CPP_LIKELY {
-                        incptr<LOOP_UNROLL_FACTOR>(first);
-                        incptr<LOOP_UNROLL_FACTOR>(last);
-                    }
+                while (first < end_unrolled && !unrolled_find_f_l<LOOP_UNROLL_FACTOR>(first, last, f, l)) TAMP_CPP_LIKELY {
+                    incptr<LOOP_UNROLL_FACTOR>(first);
+                    incptr<LOOP_UNROLL_FACTOR>(last);
+                }
 
                 if (first >= end_unrolled) {
                     // Nothing found so far.
@@ -672,13 +666,12 @@ class Locator {
     template <uint32_t M, uint32_t N = 0, typename P>
     static bool __attribute__((always_inline)) unrolled_cmp8(const P*& d1, const P*& d2) noexcept {
         if (*(p<uint8_t>(d1) + N) == *(p<uint8_t>(d2) + N)) TAMP_CPP_LIKELY {
-                if constexpr (N + 1 < M) {
-                    return unrolled_cmp8<M, N + 1>(d1, d2);
-                } else {
-                    return true;
-                }
+            if constexpr (N + 1 < M) {
+                return unrolled_cmp8<M, N + 1>(d1, d2);
+            } else {
+                return true;
             }
-        else {
+        } else {
             incptr<N>(d1);
             incptr<N>(d2);
             return false;
@@ -735,10 +728,9 @@ class Locator {
 
             while (d1 < end) {
                 if (as<uint8_t>(d1) == as<uint8_t>(d2)) TAMP_CPP_LIKELY {
-                        incptr<1>(d1);
-                        incptr<1>(d2);
-                    }
-                else {
+                    incptr<1>(d1);
+                    incptr<1>(d2);
+                } else {
                     break;
                 }
             }
@@ -1044,12 +1036,11 @@ class Locator {
                             tmp = tmp << bits;  // Remove the bit we're handling now.
                         }
                         if (s1 <= end) TAMP_CPP_LIKELY {
-                                if (cmpLen == 0 || cmp8(s1, pat1, cmpLen) >= cmpLen) {
-                                    // stats.matchFound(patLen, (s1-1)-data + patLen);
-                                    return s1 - 1;
-                                }
+                            if (cmpLen == 0 || cmp8(s1, pat1, cmpLen) >= cmpLen) {
+                                // stats.matchFound(patLen, (s1-1)-data + patLen);
+                                return s1 - 1;
                             }
-                        else {
+                        } else {
                             // Found match would extend beyond the end of data.
                             return nullptr;
                         }
@@ -1089,10 +1080,10 @@ class Locator {
                     bestMatch = match;
                     matchLen = searchLen;
                     if (searchLen < patLen) TAMP_CPP_LIKELY {
-                            // If the current match happens to extend beyond what we searched for,
-                            // we'll take that too.
-                            matchLen += cmp8(pattern + searchLen, match + searchLen, patLen - searchLen);
-                        }
+                        // If the current match happens to extend beyond what we searched for,
+                        // we'll take that too.
+                        matchLen += cmp8(pattern + searchLen, match + searchLen, patLen - searchLen);
+                    }
                     dataLen -= match + 1 - data;
                     data = match + 1;
 


### PR DESCRIPTION
Purpose for PR:
Tamp ESP-IDF component is listed to be compatible with IDF versions >=4.3, however it does not work out of the box for IDF <4.5 as there are references to many C++ 20 exclusive keywords. This PR fixes that constraint without breaking functionality.

Linked Issue:
closes #239 

Change list:
`CMakeList.txt`: 

- Remove force C++ version set to 20 for IDF versions 4.0 -> 4.4. Force C++ 17 instead.

`copyutil.hpp`: 

- Replace `requires` keyword with `static_assert`. `requires` is not available in C++ 17, but `static_assert` is available in both C++ 17 and 20.
- Fix compiler error for unused parameters.

`tamp_search.hpp`:

- Add conditional check if span library is available before attempting to import it. span is not available in C++ 17.
- Add macros to abstract `likely` and `unlikely` keywords that are not available in C++ 17.
- Ran pre-commit on file.