### PR TITLE
Add double-flush reset-dictionary feature.

### DIFF
--- a/ctests/test_compressor.c
+++ b/ctests/test_compressor.c
@@ -400,6 +400,150 @@ void test_compressor_extended_window9_roundtrip(void) {
     TEST_ASSERT_EQUAL_MEMORY(input, output, sizeof(input));
 }
 
+void test_reset_dictionary_roundtrip(void) {
+    // Basic reset dictionary roundtrip: compress, reset, compress more, decompress all.
+    tamp_res res;
+    TampCompressor compressor;
+    unsigned char c_window[1 << 10];
+    unsigned char compressed[512];
+    size_t total_written = 0;
+    size_t chunk_written, input_consumed;
+    TampConf conf = {
+        .window = 10,
+        .literal = 8,
+        .extended = true,
+        .dictionary_reset = true,
+    };
+
+    res = tamp_compressor_init(&compressor, &conf, c_window);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+
+    // Compress first chunk
+    const char *data1 = "Hello world! Hello world! Hello world! ";
+    res = tamp_compressor_compress_and_flush(&compressor, compressed, sizeof(compressed), &chunk_written,
+                                             (const unsigned char *)data1, strlen(data1), &input_consumed, true);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // Reset dictionary
+    res = tamp_compressor_reset_dictionary(&compressor, compressed + total_written, sizeof(compressed) - total_written,
+                                           &chunk_written);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // Compress second chunk
+    const char *data2 = "Goodbye world! Goodbye world! Goodbye world! ";
+    res = tamp_compressor_compress_and_flush(&compressor, compressed + total_written,
+                                             sizeof(compressed) - total_written, &chunk_written,
+                                             (const unsigned char *)data2, strlen(data2), &input_consumed, false);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // Decompress and verify
+    TampDecompressor decompressor;
+    unsigned char d_window[1 << 10];
+    unsigned char output[512];
+    size_t output_written;
+
+    res = tamp_decompressor_init(&decompressor, NULL, d_window, 10);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+
+    res = tamp_decompressor_decompress(&decompressor, output, sizeof(output), &output_written, compressed,
+                                       total_written, NULL);
+    TEST_ASSERT_GREATER_OR_EQUAL(TAMP_OK, res);
+    size_t expected_size = strlen(data1) + strlen(data2);
+    TEST_ASSERT_EQUAL(expected_size, output_written);
+    TEST_ASSERT_EQUAL_MEMORY(data1, output, strlen(data1));
+    TEST_ASSERT_EQUAL_MEMORY(data2, output + strlen(data1), strlen(data2));
+}
+
+void test_reset_dictionary_requires_conf_flag(void) {
+    // reset_dictionary must fail if dictionary_reset was not set at init.
+    tamp_res res;
+    TampCompressor compressor;
+    unsigned char window[1 << 10];
+    unsigned char output[64];
+    size_t output_written;
+    TampConf conf = {
+        .window = 10,
+        .literal = 8,
+        .dictionary_reset = false,
+    };
+
+    res = tamp_compressor_init(&compressor, &conf, window);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+
+    res = tamp_compressor_reset_dictionary(&compressor, output, sizeof(output), &output_written);
+    TEST_ASSERT_EQUAL(TAMP_INVALID_CONF, res);
+}
+
+void test_reset_dictionary_small_output_buffer(void) {
+    // If reset_dictionary gets TAMP_OUTPUT_FULL, retrying should still produce
+    // a valid stream. The retry may emit an extra FLUSH (3 total), which
+    // triggers a harmless redundant reset.
+    tamp_res res;
+    TampCompressor compressor;
+    unsigned char c_window[1 << 10];
+    unsigned char compressed[512];
+    size_t total_written = 0;
+    size_t chunk_written, input_consumed;
+    TampConf conf = {
+        .window = 10,
+        .literal = 8,
+        .extended = true,
+        .dictionary_reset = true,
+    };
+
+    res = tamp_compressor_init(&compressor, &conf, c_window);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+
+    // Compress some data so there's pending state to flush.
+    const char *data1 = "The quick brown fox jumps over the lazy dog. ";
+    res = tamp_compressor_compress(&compressor, compressed, sizeof(compressed), &chunk_written,
+                                   (const unsigned char *)data1, strlen(data1), &input_consumed);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // Try reset with a tiny buffer — should fail with TAMP_OUTPUT_FULL.
+    res = tamp_compressor_reset_dictionary(&compressor, compressed + total_written, 1, &chunk_written);
+    TEST_ASSERT_EQUAL(TAMP_OUTPUT_FULL, res);
+    // Note: some flush output may have been written even on failure.
+    total_written += chunk_written;
+
+    // Retry with enough space — should succeed.
+    res = tamp_compressor_reset_dictionary(&compressor, compressed + total_written, sizeof(compressed) - total_written,
+                                           &chunk_written);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // Compress more data after reset.
+    const char *data2 = "New data after reset! New data after reset! ";
+    res = tamp_compressor_compress_and_flush(&compressor, compressed + total_written,
+                                             sizeof(compressed) - total_written, &chunk_written,
+                                             (const unsigned char *)data2, strlen(data2), &input_consumed, false);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // Decompress and verify the full stream is valid.
+    TampDecompressor decompressor;
+    unsigned char d_window[1 << 10];
+    unsigned char output[512];
+    size_t output_written;
+
+    res = tamp_decompressor_init(&decompressor, NULL, d_window, 10);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+
+    res = tamp_decompressor_decompress(&decompressor, output, sizeof(output), &output_written, compressed,
+                                       total_written, NULL);
+    TEST_ASSERT_GREATER_OR_EQUAL(TAMP_OK, res);
+
+    // The output should contain data1 + data2 (the extra reset is harmless).
+    size_t expected_size = strlen(data1) + strlen(data2);
+    TEST_ASSERT_EQUAL(expected_size, output_written);
+    TEST_ASSERT_EQUAL_MEMORY(data1, output, strlen(data1));
+    TEST_ASSERT_EQUAL_MEMORY(data2, output + strlen(data1), strlen(data2));
+}
+
 void test_compress_cb_callback_abort(void) {
     TampCompressor compressor;
     unsigned char window[1 << 10];

--- a/ctests/test_runner.c
+++ b/ctests/test_runner.c
@@ -35,6 +35,9 @@ int main(void) {
 #endif
     RUN_TEST(test_compress_cb_callback_receives_input_consumed);
     RUN_TEST(test_compress_cb_callback_abort);
+    RUN_TEST(test_reset_dictionary_roundtrip);
+    RUN_TEST(test_reset_dictionary_requires_conf_flag);
+    RUN_TEST(test_reset_dictionary_small_output_buffer);
 
     // Decompressor extended tests
     RUN_TEST(test_decompressor_extended_rle);

--- a/docs/source/c_library.rst
+++ b/docs/source/c_library.rst
@@ -158,6 +158,11 @@ The provided buffer must be at least ``(1 << conf.window)`` bytes.
       unaffected.
       Only available when compiled with -DTAMP_EXTENDED_COMPRESS=1 (default). */
       .extended = true,
+
+      /* Enable dictionary reset / append support (v2.1.0+).
+      Adds a second header byte; old decompressors reject the stream.
+      Required for reset_dictionary() and append mode. */
+      .dictionary_reset = false,
    };
    TampCompressor compressor;
    tamp_compressor_init(&compressor, &conf, window_buffer);
@@ -230,6 +235,80 @@ The ``write_token`` parameter controls whether a ``FLUSH`` token is appended whe
 
 * Set to ``true`` if you intend to continue using the compressor. The ``FLUSH`` token adds 0~2 bytes of overhead.
 * Set to ``false`` when finalizing a stream, to save 0~2 bytes.
+
+When ``dictionary_reset`` is enabled, ``write_token=true`` **always** emits a
+FLUSH token (even when byte-aligned), and closing the stream emits one
+automatically. This enables the append mode described below.
+
+Dictionary Reset
+----------------
+
+.. note::
+
+   New in v2.1.0. Requires v2.1.0+ compressor and decompressor.
+
+Dictionary reset allows appending new compressed data to an existing stream
+without retaining the previous compressor state. After a reset, both compressor
+and decompressor start fresh with a default dictionary, so no prior window
+buffer, input buffer, or bit buffer state needs to be persisted.
+
+``tamp_compressor_reset_dictionary`` writes a double-FLUSH signal, resets the
+dictionary and all internal state, then continues with the same configuration.
+The decompressor handles double-FLUSH resets automatically.
+
+Requires ``.dictionary_reset = true`` in ``TampConf``, which adds a second
+header byte. Older decompressors reject the stream at the header level.
+Returns ``TAMP_INVALID_CONF`` if not set.
+
+.. code-block:: c
+
+   TampConf conf = {.window = 10, .literal = 8, .dictionary_reset = true};
+   TampCompressor compressor;
+   tamp_compressor_init(&compressor, &conf, window_buffer);
+
+   // ... compress some data ...
+
+   unsigned char reset_buffer[32];  // Worst case: 27 bytes
+   size_t reset_written;
+   res = tamp_compressor_reset_dictionary(&compressor, reset_buffer,
+                                          sizeof(reset_buffer), &reset_written);
+   // Append reset_buffer[0..reset_written] to output, then continue compressing.
+
+Append Mode
+~~~~~~~~~~~
+Set ``.append = true`` to resume compression on an existing stream without
+persisting compressor state. Requires:
+
+1. The previous compression stream to have had ``dictionary_reset = true``.
+
+2. The new compressor to have the same configuration as the previous compressor (same ``window_bits``, ``literal``, etc).
+
+Writes a byte-aligned
+FLUSH token to the internal bit buffer instead of a header. Combined with the
+previous stream's trailing FLUSH, this forms a double-FLUSH that resets the
+decompressor's dictionary.
+
+Requires ``dictionary_reset = true`` and ``use_custom_dictionary = false``.
+
+.. code-block:: c
+
+   // Session 1
+   TampConf conf = {.window = 10, .literal = 8, .dictionary_reset = true};
+   TampCompressor compressor;
+   tamp_compressor_init(&compressor, &conf, window_buffer);
+   tamp_compressor_compress_and_flush(&compressor, output, output_size,
+                                      &output_written, input, input_size,
+                                      &input_consumed, true);
+   // Save output to storage (stream ends with FLUSH token).
+
+   // Session 2
+   conf.append = true;
+   TampCompressor compressor2;
+   tamp_compressor_init(&compressor2, &conf, window_buffer);
+   tamp_compressor_compress_and_flush(&compressor2, output, output_size,
+                                      &output_written, new_input, new_input_size,
+                                      &input_consumed, true);
+   // Append output to storage.
 
 Lazy Matching
 -------------

--- a/docs/source/javascript.rst
+++ b/docs/source/javascript.rst
@@ -99,7 +99,7 @@ Use streaming compression for processing large files or data that does not fit i
 
    // Dictionary reset mid-stream; useful if we need to append
    // data to a compression stream.
-   await using(new TampCompressor(options), async (compressor) => {
+   await using(new TampCompressor({ ...options, dictionary_reset: true }), async (compressor) => {
      // Compress first segment
      compressedChunks.push(await compressor.compress(segment1));
 

--- a/docs/source/javascript.rst
+++ b/docs/source/javascript.rst
@@ -97,6 +97,23 @@ Use streaming compression for processing large files or data that does not fit i
      }
    });
 
+   // Dictionary reset mid-stream; useful if we need to append
+   // data to a compression stream.
+   await using(new TampCompressor(options), async (compressor) => {
+     // Compress first segment
+     compressedChunks.push(await compressor.compress(segment1));
+
+     // Reset dictionary
+     const resetBytes = await compressor.resetDictionary();
+     if (resetBytes.length > 0) {
+       compressedChunks.push(resetBytes);
+     }
+
+     // Continue compressing with a fresh dictionary
+     compressedChunks.push(await compressor.compress(segment2));
+     compressedChunks.push(await compressor.flush());
+   });
+
 
 Web Streams Integration
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -285,15 +285,16 @@ Since the output bit stream must be byte-aligned for writing, there may be up to
 pending bits that have not yet formed a complete byte.
 Invoking the ``flush`` method can have one of two results:
 
-1. If the output is already byte-aligned, no action is performed.
+1. If the output is already byte-aligned and ``more_header`` is not set,
+   no action is performed.
 
-2. If there are pending bits, the FLUSH Huffman code is written.
+2. If there are pending bits, or if ``more_header`` is set, the FLUSH Huffman
+   code is written.
    No ``offset`` bits are written following the FLUSH code.
    The remaining bits are zero-padded to the next byte boundary.
 
 On reading, if a FLUSH is read, the reader discards the remaining bits up to the
 next byte boundary.
-In the best case (already byte-aligned), no FLUSH symbol is emitted.
 When ``more_header`` is set, a FLUSH is **always** emitted (even when byte-aligned)
 to support append mode (see `Dictionary Reset (Double-FLUSH)`_).
 In the worst case (1 pending bit), a FLUSH symbol (9 bits) and 6 padding bits are

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -29,9 +29,18 @@ The bit-location 0 is equivalent to typical MSb position 7 of the first byte.
 | [1]     | extended          | Enables extended format features (RLE, extended match encoding).    |
 |         |                   | Generally improves compression, introduced in tamp v2.0.0.          |
 +---------+-------------------+---------------------------------------------------------------------+
-| [0]     | more_header       | If ``True``, then the next byte in the stream is more header data.  |
-|         |                   | Currently always ``False``, but allows for future expandability.    |
+| [0]     | more_header       | Next byte is header byte 2 (see `Header Byte 2`_). Implies         |
+|         |                   | ``dictionary_reset``: stream may contain double-FLUSH resets.       |
+|         |                   | Old decompressors reject the stream at the header.                  |
 +---------+-------------------+---------------------------------------------------------------------+
+
+.. _header-byte-2:
+
+Header Byte 2
+~~~~~~~~~~~~~
+Present only when ``more_header`` (bit 0 of byte 1) is set.
+All 8 bits are reserved for future use and must be ``0``.
+Decompressors must reject non-zero values with ``TAMP_INVALID_CONF``.
 
 Stream Encoding/Decoding
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -285,10 +294,31 @@ Invoking the ``flush`` method can have one of two results:
 On reading, if a FLUSH is read, the reader discards the remaining bits up to the
 next byte boundary.
 In the best case (already byte-aligned), no FLUSH symbol is emitted.
+When ``more_header`` is set, a FLUSH is **always** emitted (even when byte-aligned)
+to support append mode (see `Dictionary Reset (Double-FLUSH)`_).
 In the worst case (1 pending bit), a FLUSH symbol (9 bits) and 6 padding bits are
 written, adding 15 bits of overhead to the output stream.
 
-At the very end of a stream, the FLUSH symbol is unnecessary and **may be omitted** to save an additional one or two bytes.
+
+Dictionary Reset (Double-FLUSH)
+-------------------------------
+Dictionary reset allows appending new compressed data to an existing stream
+without retaining the previous compressor state. After a reset, both sides
+start fresh with a default dictionary.
+
+When the ``more_header`` (header byte 1, bit 0) is set, two consecutive FLUSH tokens signal a dictionary reset.
+Without ``more_header``, double-FLUSHes are treated as two ordinary flushes.
+Old decompressors (<2.1.0) reject ``more_header`` streams at the header, preventing silent corruption.
+
+On the compressor side, ``reset_dictionary`` flushes pending data, writes
+exactly two consecutive FLUSHes, then re-initializes the window and all
+internal state.
+
+On the decompressor side:
+1. Re-initializes the window (see `Dictionary Initialization`_). Custom dictionaries cannot be supplied at this time.
+2. Resets window position to zero.
+3. Continues decompressing with a fresh dictionary.
+
 
 Miscellaneous
 ^^^^^^^^^^^^^

--- a/mpy_bindings/bindings.c
+++ b/mpy_bindings/bindings.c
@@ -61,7 +61,7 @@ typedef struct {
 } mp_obj_compressor_t;
 
 mp_obj_full_type_t mp_type_compressor;          // This is type(Compressor)
-mp_map_elem_t compressor_locals_dict_table[2];  // Number of Compressor methods/attributes
+mp_map_elem_t compressor_locals_dict_table[3];  // Number of Compressor methods/attributes
 static MP_DEFINE_CONST_DICT(compressor_locals_dict, compressor_locals_dict_table);
 
 // Essentially Compressor.__new__ (but also kind of __init__).
@@ -71,6 +71,7 @@ static mp_obj_t compressor_make_new(const mp_obj_type_t *type, size_t n_args, si
         .literal = mp_obj_get_int(args_in[2]),
         .use_custom_dictionary = mp_obj_get_int(args_in[4]),
         .extended = mp_obj_get_int(args_in[5]),
+        .dictionary_reset = mp_obj_get_int(args_in[6]),
     };
 
     mp_obj_compressor_t *o = mp_obj_malloc(mp_obj_compressor_t, type);
@@ -130,6 +131,22 @@ static mp_obj_t compressor_flush(mp_obj_t self_in, mp_obj_t write_token_in) {
     return mp_obj_new_int(output_written_size);
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(compressor_flush_obj, compressor_flush);
+
+static mp_obj_t compressor_reset_dictionary(mp_obj_t self_in) {
+    mp_obj_compressor_t *self = MP_OBJ_TO_PTR(self_in);
+    uint8_t output_buffer[32];  // Worst case: 23 (flush) + 4 (2x FLUSH) = 27 bytes
+    size_t output_written_size;
+
+    TAMP_CHECK(tamp_compressor_reset_dictionary(&self->c, output_buffer, sizeof(output_buffer), &output_written_size));
+    if (output_written_size) {
+        mp_obj_t bytes_obj = mp_obj_new_bytes(output_buffer, output_written_size);
+        mp_obj_t write_method = mp_load_attr(self->f, MP_QSTR_write);
+        mp_call_function_n_kw(write_method, 1, 0, &bytes_obj);
+    }
+
+    return mp_obj_new_int(output_written_size);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(compressor_reset_dictionary_obj, compressor_reset_dictionary);
 #endif
 
 /****************
@@ -265,6 +282,8 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
         (mp_map_elem_t){MP_OBJ_NEW_QSTR(MP_QSTR_write), MP_OBJ_FROM_PTR(&compressor_write_obj)};
     compressor_locals_dict_table[1] =
         (mp_map_elem_t){MP_OBJ_NEW_QSTR(MP_QSTR_flush), MP_OBJ_FROM_PTR(&compressor_flush_obj)};
+    compressor_locals_dict_table[2] =
+        (mp_map_elem_t){MP_OBJ_NEW_QSTR(MP_QSTR_reset_dictionary), MP_OBJ_FROM_PTR(&compressor_reset_dictionary_obj)};
 
     // Make the _Compressor type available on the module.
     mp_store_global(MP_QSTR__C, MP_OBJ_FROM_PTR(&mp_type_compressor));

--- a/mpy_bindings/bindings.c
+++ b/mpy_bindings/bindings.c
@@ -84,7 +84,12 @@ static mp_obj_t compressor_make_new(const mp_obj_type_t *type, size_t n_args, si
         mp_raise_ValueError("");
     }
 
-    TAMP_CHECK(tamp_compressor_init(&o->c, &conf, dictionary_buffer_info.buf));
+    bool append = mp_obj_get_int(args_in[7]);
+    if (append) {
+        TAMP_CHECK(tamp_compressor_init_append(&o->c, &conf, dictionary_buffer_info.buf));
+    } else {
+        TAMP_CHECK(tamp_compressor_init(&o->c, &conf, dictionary_buffer_info.buf));
+    }
 
     return MP_OBJ_FROM_PTR(o);
 }

--- a/mpy_bindings/bindings.c
+++ b/mpy_bindings/bindings.c
@@ -84,12 +84,8 @@ static mp_obj_t compressor_make_new(const mp_obj_type_t *type, size_t n_args, si
         mp_raise_ValueError("");
     }
 
-    bool append = mp_obj_get_int(args_in[7]);
-    if (append) {
-        TAMP_CHECK(tamp_compressor_init_append(&o->c, &conf, dictionary_buffer_info.buf));
-    } else {
-        TAMP_CHECK(tamp_compressor_init(&o->c, &conf, dictionary_buffer_info.buf));
-    }
+    conf.append = mp_obj_get_int(args_in[7]);
+    TAMP_CHECK(tamp_compressor_init(&o->c, &conf, dictionary_buffer_info.buf));
 
     return MP_OBJ_FROM_PTR(o);
 }

--- a/mpy_bindings/bindings_compressor.py
+++ b/mpy_bindings/bindings_compressor.py
@@ -11,6 +11,7 @@ class Compressor:
         dictionary=None,
         extended=True,
         dictionary_reset=False,
+        append=False,
     ):
         self._cf = False  # shorter name to save binary space
         if not hasattr(f, "write"):  # It's probably a path-like object.
@@ -20,7 +21,7 @@ class Compressor:
         custom = dictionary is not None
         if not dictionary:
             dictionary = bytearray(1 << window)
-        self._c = _C(f, window, literal, dictionary, custom, extended, dictionary_reset)
+        self._c = _C(f, window, literal, dictionary, custom, extended, dictionary_reset, append)
 
         self.write = self._c.write
 

--- a/mpy_bindings/bindings_compressor.py
+++ b/mpy_bindings/bindings_compressor.py
@@ -10,6 +10,7 @@ class Compressor:
         literal=8,
         dictionary=None,
         extended=True,
+        dictionary_reset=False,
     ):
         self._cf = False  # shorter name to save binary space
         if not hasattr(f, "write"):  # It's probably a path-like object.
@@ -19,7 +20,7 @@ class Compressor:
         custom = dictionary is not None
         if not dictionary:
             dictionary = bytearray(1 << window)
-        self._c = _C(f, window, literal, dictionary, custom, extended)
+        self._c = _C(f, window, literal, dictionary, custom, extended, dictionary_reset)
 
         self.write = self._c.write
 
@@ -31,6 +32,9 @@ class Compressor:
 
     def flush(self, write_token=True):
         return self._c.flush(write_token)
+
+    def reset_dictionary(self):
+        return self._c.reset_dictionary()
 
     def __enter__(self):
         return self

--- a/mpy_bindings/bindings_compressor.py
+++ b/mpy_bindings/bindings_compressor.py
@@ -21,12 +21,15 @@ class Compressor:
         custom = dictionary is not None
         if not dictionary:
             dictionary = bytearray(1 << window)
+        self._dr = dictionary_reset
         self._c = _C(f, window, literal, dictionary, custom, extended, dictionary_reset, append)
 
         self.write = self._c.write
 
     def close(self) -> int:
-        bytes_written = self.flush(False)
+        # When dictionary_reset is enabled, always end with a FLUSH token
+        # so that a future append-mode compressor can form a double-FLUSH.
+        bytes_written = self.flush(self._dr)
         if self._cf:
             self.f.close()
         return bytes_written

--- a/tamp/_c_compressor.pyx
+++ b/tamp/_c_compressor.pyx
@@ -37,6 +37,7 @@ cdef class Compressor:
         bool lazy_matching=False,
         bool extended=True,
         bool dictionary_reset=False,
+        bool append=False,
     ):
         cdef ctamp.TampConf conf
 
@@ -63,7 +64,10 @@ cdef class Compressor:
         self._window_buffer = dictionary if dictionary else bytearray(1 << window)
         self._window_buffer_ptr = <unsigned char *>self._window_buffer
 
-        res = ctamp.tamp_compressor_init(self._c_compressor, &conf, self._window_buffer_ptr)
+        if append:
+            res = ctamp.tamp_compressor_init_append(self._c_compressor, &conf, self._window_buffer_ptr)
+        else:
+            res = ctamp.tamp_compressor_init(self._c_compressor, &conf, self._window_buffer_ptr)
         if res < 0:
             raise ERROR_LOOKUP.get(res, NotImplementedError)
 

--- a/tamp/_c_compressor.pyx
+++ b/tamp/_c_compressor.pyx
@@ -36,6 +36,7 @@ cdef class Compressor:
         dictionary=None,
         bool lazy_matching=False,
         bool extended=True,
+        bool dictionary_reset=False,
     ):
         cdef ctamp.TampConf conf
 
@@ -57,6 +58,7 @@ cdef class Compressor:
         # The build system defines this macro, so the field should be available
         conf.lazy_matching = lazy_matching
         conf.extended = extended
+        conf.dictionary_reset = dictionary_reset
 
         self._window_buffer = dictionary if dictionary else bytearray(1 << window)
         self._window_buffer_ptr = <unsigned char *>self._window_buffer
@@ -113,6 +115,28 @@ cdef class Compressor:
             len(buffer),
             &output_written_size,
             write_token,
+        )
+
+        if res < 0:
+            raise ERROR_LOOKUP.get(res, NotImplementedError)
+
+        if output_written_size:
+            self.f.write(buffer[:output_written_size])
+
+        self.f.flush()
+
+        return output_written_size
+
+    cpdef int reset_dictionary(self) except -1:
+        cdef ctamp.tamp_res res
+        cdef bytearray buffer = bytearray(64)
+        cdef size_t output_written_size = 0
+
+        res = ctamp.tamp_compressor_reset_dictionary(
+            self._c_compressor,
+            <unsigned char *> buffer,
+            len(buffer),
+            &output_written_size,
         )
 
         if res < 0:

--- a/tamp/_c_compressor.pyx
+++ b/tamp/_c_compressor.pyx
@@ -18,6 +18,7 @@ cdef class Compressor:
     cdef unsigned char *_window_buffer_ptr
     cdef object f
     cdef bint _close_f_on_close
+    cdef bint _dictionary_reset
 
     def __cinit__(self):
         self._c_compressor = <ctamp.TampCompressor*>PyMem_Malloc(sizeof(ctamp.TampCompressor))
@@ -60,14 +61,13 @@ cdef class Compressor:
         conf.lazy_matching = lazy_matching
         conf.extended = extended
         conf.dictionary_reset = dictionary_reset
+        conf.append = append
 
         self._window_buffer = dictionary if dictionary else bytearray(1 << window)
         self._window_buffer_ptr = <unsigned char *>self._window_buffer
 
-        if append:
-            res = ctamp.tamp_compressor_init_append(self._c_compressor, &conf, self._window_buffer_ptr)
-        else:
-            res = ctamp.tamp_compressor_init(self._c_compressor, &conf, self._window_buffer_ptr)
+        self._dictionary_reset = dictionary_reset
+        res = ctamp.tamp_compressor_init(self._c_compressor, &conf, self._window_buffer_ptr)
         if res < 0:
             raise ERROR_LOOKUP.get(res, NotImplementedError)
 
@@ -154,7 +154,9 @@ cdef class Compressor:
         return output_written_size
 
     def close(self) -> int:
-        bytes_written = self.flush(write_token=False)
+        # When dictionary_reset is enabled, always end with a FLUSH token
+        # so that a future append-mode compressor can form a double-FLUSH.
+        bytes_written = self.flush(write_token=self._dictionary_reset)
         if self._close_f_on_close:
             self.f.close()
         return bytes_written

--- a/tamp/_c_compressor.pyx
+++ b/tamp/_c_compressor.pyx
@@ -129,7 +129,7 @@ cdef class Compressor:
 
     cpdef int reset_dictionary(self) except -1:
         cdef ctamp.tamp_res res
-        cdef bytearray buffer = bytearray(64)
+        cdef bytearray buffer = bytearray(32)  # Worst case: 23 (flush) + 4 (2x FLUSH) = 27 bytes
         cdef size_t output_written_size = 0
 
         res = ctamp.tamp_compressor_reset_dictionary(

--- a/tamp/_c_decompressor.pyx
+++ b/tamp/_c_decompressor.pyx
@@ -49,11 +49,19 @@ cdef class Decompressor:
         self.input_size = 0
         self.input_consumed = 0
 
-        compressed_data = f.read(1)
+        # Read header incrementally (1 byte at a time) so we don't require seek support.
+        cdef bytearray header_buf = bytearray()
+        while True:
+            b = f.read(1)
+            if not b:
+                raise ERROR_LOOKUP.get(ctamp.TAMP_INPUT_EXHAUSTED, NotImplementedError)
+            header_buf += b
+            res = ctamp.tamp_decompressor_read_header(&conf, header_buf, len(header_buf), &input_consumed_size)
+            if res == ctamp.TAMP_OK:
+                break
+            if res != ctamp.TAMP_INPUT_EXHAUSTED:
+                raise ERROR_LOOKUP.get(res, NotImplementedError)
 
-        res = ctamp.tamp_decompressor_read_header(&conf, compressed_data, len(compressed_data), &input_consumed_size);
-        if res != ctamp.TAMP_OK:
-            raise ERROR_LOOKUP.get(res, NotImplementedError)
         if conf.use_custom_dictionary and dictionary is None:
             raise ValueError
 

--- a/tamp/_c_src/tamp/common.h
+++ b/tamp/_c_src/tamp/common.h
@@ -162,6 +162,7 @@ typedef struct TampConf {
     uint16_t literal : 4;                // number of literal bits
     uint16_t use_custom_dictionary : 1;  // Use a custom initialized dictionary.
     uint16_t extended : 1;               // Extended format (RLE, extended match). Read from header bit [1].
+    uint16_t dictionary_reset : 1;       // Stream may contain double-FLUSH dictionary resets. Header byte 2 bit [7].
 #if TAMP_LAZY_MATCHING
     uint16_t lazy_matching : 1;  // use Lazy Matching (spend 50-75% more CPU for around 0.5-2.0% better compression.)
                                  // only effects compression operations.

--- a/tamp/_c_src/tamp/common.h
+++ b/tamp/_c_src/tamp/common.h
@@ -163,6 +163,7 @@ typedef struct TampConf {
     uint16_t use_custom_dictionary : 1;  // Use a custom initialized dictionary.
     uint16_t extended : 1;               // Extended format (RLE, extended match). Read from header bit [1].
     uint16_t dictionary_reset : 1;       // Stream may contain double-FLUSH dictionary resets. Header byte 2 bit [7].
+    uint16_t append : 1;                 // Initialize for appending to an existing stream (FLUSH instead of header).
 #if TAMP_LAZY_MATCHING
     uint16_t lazy_matching : 1;  // use Lazy Matching (spend 50-75% more CPU for around 0.5-2.0% better compression.)
                                  // only effects compression operations.

--- a/tamp/_c_src/tamp/common.h
+++ b/tamp/_c_src/tamp/common.h
@@ -162,8 +162,9 @@ typedef struct TampConf {
     uint16_t literal : 4;                // number of literal bits
     uint16_t use_custom_dictionary : 1;  // Use a custom initialized dictionary.
     uint16_t extended : 1;               // Extended format (RLE, extended match). Read from header bit [1].
-    uint16_t dictionary_reset : 1;       // Stream may contain double-FLUSH dictionary resets. Implied by header byte 1 bit 0 (`more_header`); header byte 2 is currently reserved/zero.
-    uint16_t append : 1;                 // Initialize for appending to an existing stream (FLUSH instead of header).
+    uint16_t dictionary_reset : 1;  // Stream may contain double-FLUSH dictionary resets. Implied by header byte 1 bit
+                                    // [0] (more_header).
+    uint16_t append : 1;            // Initialize for appending to an existing stream (FLUSH instead of header).
 #if TAMP_LAZY_MATCHING
     uint16_t lazy_matching : 1;  // use Lazy Matching (spend 50-75% more CPU for around 0.5-2.0% better compression.)
                                  // only effects compression operations.

--- a/tamp/_c_src/tamp/common.h
+++ b/tamp/_c_src/tamp/common.h
@@ -162,7 +162,7 @@ typedef struct TampConf {
     uint16_t literal : 4;                // number of literal bits
     uint16_t use_custom_dictionary : 1;  // Use a custom initialized dictionary.
     uint16_t extended : 1;               // Extended format (RLE, extended match). Read from header bit [1].
-    uint16_t dictionary_reset : 1;       // Stream may contain double-FLUSH dictionary resets. Header byte 2 bit [7].
+    uint16_t dictionary_reset : 1;       // Stream may contain double-FLUSH dictionary resets. Implied by header byte 1 bit 0 (`more_header`); header byte 2 is currently reserved/zero.
     uint16_t append : 1;                 // Initialize for appending to an existing stream (FLUSH instead of header).
 #if TAMP_LAZY_MATCHING
     uint16_t lazy_matching : 1;  // use Lazy Matching (spend 50-75% more CPU for around 0.5-2.0% better compression.)

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -806,7 +806,7 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_reset_dictionary(TampCompressor* com
     *output_written_size = 0;
 
     // Flush all pending data with write_token=true so the stream is byte-aligned.
-    // flush_token_written tells us if a FLUSH was emitted (only when bit_buffer_pos > 0).
+    // flush_token_written tells us if a FLUSH was emitted (when bit_buffer_pos > 0 or dictionary_reset is set).
     // If the compressor is already idle (e.g. retry after TAMP_OUTPUT_FULL),
     // flush_impl is a no-op and flush_token_written stays false.
     uint8_t flushes_needed;

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -183,18 +183,12 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
     if (!conf) conf = &conf_default;
     if (conf->window < 8 || conf->window > 15) return TAMP_INVALID_CONF;
     if (conf->literal < 5 || conf->literal > 8) return TAMP_INVALID_CONF;
+    if (conf->append && (!conf->dictionary_reset || conf->use_custom_dictionary)) return TAMP_INVALID_CONF;
 #if !TAMP_EXTENDED_COMPRESS
     if (conf->extended) return TAMP_INVALID_CONF;  // Extended requested but not compiled in
 #endif
 
     TAMP_MEMSET(compressor, 0, sizeof(TampCompressor));
-
-    // Build header byte 1 (8 bits)
-    // Layout: [window:3][literal:2][use_custom_dictionary:1][extended:1][more_headers:1]
-    // TODO: OR in any future second-header-byte flags here.
-    bool has_second_header = conf->dictionary_reset;
-    uint8_t header = ((conf->window - 8) << 5) | ((conf->literal - 5) << 3) | (conf->use_custom_dictionary << 2) |
-                     (conf->extended << 1) | has_second_header;
 
     compressor->conf = *conf;  // Single struct copy
     compressor->window = window;
@@ -207,27 +201,25 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
     if (!conf->use_custom_dictionary)
         tamp_initialize_dictionary(window, (1 << conf->window), conf->extended ? conf->literal : 8);
 
-    write_to_bit_buffer(compressor, header, 8);
+    if (conf->append) {
+        // Write a FLUSH token instead of a header. Combined with the previous
+        // stream's trailing FLUSH, this triggers a dictionary reset in the
+        // decompressor. Flushed out naturally by the next compress/flush call.
+        write_to_bit_buffer(compressor, FLUSH_CODE, 9);
+    } else {
+        // Build header byte 1 (8 bits)
+        // Layout: [window:3][literal:2][use_custom_dictionary:1][extended:1][more_headers:1]
+        // TODO: OR in any future second-header-byte flags here.
+        bool has_second_header = conf->dictionary_reset;
+        uint8_t header = ((conf->window - 8) << 5) | ((conf->literal - 5) << 3) | (conf->use_custom_dictionary << 2) |
+                         (conf->extended << 1) | has_second_header;
+        write_to_bit_buffer(compressor, header, 8);
 
-    if (has_second_header) {
-        // Header byte 2: all bits reserved for future use, currently all zero.
-        write_to_bit_buffer(compressor, 0, 8);
+        if (has_second_header) {
+            // Header byte 2: all bits reserved for future use, currently all zero.
+            write_to_bit_buffer(compressor, 0, 8);
+        }
     }
-
-    return TAMP_OK;
-}
-
-tamp_res tamp_compressor_init_append(TampCompressor* compressor, const TampConf* conf, unsigned char* window) {
-    if (!conf || !conf->dictionary_reset || conf->use_custom_dictionary) return TAMP_INVALID_CONF;
-
-    tamp_res res = tamp_compressor_init(compressor, conf, window);
-    if (res != TAMP_OK) return res;
-
-    // Replace the header in the bit buffer with a FLUSH token.
-    // It will be flushed out naturally by the next compress/flush call.
-    compressor->bit_buffer = 0;
-    compressor->bit_buffer_pos = 0;
-    write_to_bit_buffer(compressor, FLUSH_CODE, 9);
 
     return TAMP_OK;
 }

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -191,6 +191,7 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
 
     // Build header byte 1 (8 bits)
     // Layout: [window:3][literal:2][use_custom_dictionary:1][extended:1][more_headers:1]
+    // TODO: OR in any future second-header-byte flags here.
     bool has_second_header = conf->dictionary_reset;
     uint8_t header = ((conf->window - 8) << 5) | ((conf->literal - 5) << 3) | (conf->use_custom_dictionary << 2) |
                      (conf->extended << 1) | has_second_header;

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -204,8 +204,11 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
     if (conf->append) {
         // Write a FLUSH token instead of a header. Combined with the previous
         // stream's trailing FLUSH, this triggers a dictionary reset in the
-        // decompressor. Flushed out naturally by the next compress/flush call.
+        // decompressor. Pad to byte boundary so subsequent compressed data
+        // starts cleanly after the decompressor discards FLUSH padding bits.
         write_to_bit_buffer(compressor, FLUSH_CODE, 9);
+        // Pad the remaining 7 bits to fill 2 bytes (bits are already zero from memset).
+        compressor->bit_buffer_pos = 16;
     } else {
         // Build header byte 1 (8 bits)
         // Layout: [window:3][literal:2][use_custom_dictionary:1][extended:1][more_headers:1]

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -217,6 +217,21 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
     return TAMP_OK;
 }
 
+tamp_res tamp_compressor_init_append(TampCompressor* compressor, const TampConf* conf, unsigned char* window) {
+    if (!conf || !conf->dictionary_reset || conf->use_custom_dictionary) return TAMP_INVALID_CONF;
+
+    tamp_res res = tamp_compressor_init(compressor, conf, window);
+    if (res != TAMP_OK) return res;
+
+    // Replace the header in the bit buffer with a FLUSH token.
+    // It will be flushed out naturally by the next compress/flush call.
+    compressor->bit_buffer = 0;
+    compressor->bit_buffer_pos = 0;
+    write_to_bit_buffer(compressor, FLUSH_CODE, 9);
+
+    return TAMP_OK;
+}
+
 #if TAMP_EXTENDED_COMPRESS
 /**
  * @brief Write extended huffman encoding (huffman + trailing bits).
@@ -718,7 +733,7 @@ flush_check:
 flush_done:
     // At this point, up to 7 bits may remain in the compressor->bit_buffer
     // The output buffer may have 0 bytes remaining.
-    if (write_token && compressor->bit_buffer_pos) {
+    if (write_token && (compressor->bit_buffer_pos || compressor->conf.dictionary_reset)) {
         // We don't want to write the FLUSH token to the bit_buffer unless
         // we are confident that it'll wind up in the output buffer
         // in THIS function call.

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -189,10 +189,11 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
 
     TAMP_MEMSET(compressor, 0, sizeof(TampCompressor));
 
-    // Build header directly from conf (8 bits total)
+    // Build header byte 1 (8 bits)
     // Layout: [window:3][literal:2][use_custom_dictionary:1][extended:1][more_headers:1]
+    bool has_second_header = conf->dictionary_reset;
     uint8_t header = ((conf->window - 8) << 5) | ((conf->literal - 5) << 3) | (conf->use_custom_dictionary << 2) |
-                     (conf->extended << 1);
+                     (conf->extended << 1) | has_second_header;
 
     compressor->conf = *conf;  // Single struct copy
     compressor->window = window;
@@ -206,6 +207,11 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
         tamp_initialize_dictionary(window, (1 << conf->window), conf->extended ? conf->literal : 8);
 
     write_to_bit_buffer(compressor, header, 8);
+
+    if (has_second_header) {
+        // Header byte 2: all bits reserved for future use, currently all zero.
+        write_to_bit_buffer(compressor, 0, 8);
+    }
 
     return TAMP_OK;
 }
@@ -776,6 +782,68 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_compress_and_flush_cb(TampCompressor
     }
 
     return TAMP_OK;
+}
+
+TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_reset_dictionary(TampCompressor* compressor, unsigned char* output,
+                                                             size_t output_size, size_t* output_written_size) {
+    if (!compressor->conf.dictionary_reset) return TAMP_INVALID_CONF;
+
+    tamp_res res;
+    size_t output_written_size_proxy;
+
+    if (!output_written_size) output_written_size = &output_written_size_proxy;
+    *output_written_size = 0;
+
+    // Flush all pending data with write_token=true so the stream is byte-aligned.
+    // flush_token_written tells us if a FLUSH was emitted (only when bit_buffer_pos > 0).
+    // If the compressor is already idle (e.g. retry after TAMP_OUTPUT_FULL),
+    // flush_impl is a no-op and flush_token_written stays false.
+    uint8_t flushes_needed;
+    {
+        size_t flush_written_size;
+        bool flush_token_written;
+        res = tamp_compressor_flush_impl(compressor, output, output_size, &flush_written_size, true,
+                                         &flush_token_written);
+        *output_written_size += flush_written_size;
+        if (TAMP_UNLIKELY(res != TAMP_OK)) return res;
+        output += flush_written_size;
+        output_size -= flush_written_size;
+
+        // We need exactly 2 consecutive FLUSHes in the stream (the reset signal).
+        // If flush_impl already wrote one, we need 1 more; otherwise 2.
+        // Each FLUSH is 9 bits → 2 bytes max after byte-alignment.
+        flushes_needed = flush_token_written ? 1 : 2;
+    }
+    // Each FLUSH is 9 bits; after byte-alignment padding, at most 2 bytes each.
+    if (TAMP_UNLIKELY(output_size < (size_t)flushes_needed * 2)) return TAMP_OUTPUT_FULL;
+
+    // Space is guaranteed; writes below cannot fail.
+    for (uint8_t i = 0; i < flushes_needed; i++) {
+        write_to_bit_buffer(compressor, FLUSH_CODE, 9);
+        // Pad to byte boundary (bit_buffer_pos is 9 here: partial_flush writes
+        // 1 byte leaving 1 bit, then we write the trailing partial byte).
+        partial_flush(compressor, &output, &output_size, output_written_size);
+        if (compressor->bit_buffer_pos) {
+            *output++ = compressor->bit_buffer >> 24;
+            output_size--;
+            (*output_written_size)++;
+            compressor->bit_buffer_pos = 0;
+            compressor->bit_buffer = 0;
+        }
+    }
+
+    // Re-initialize compressor, then discard the header it writes to the bit buffer.
+
+    // Copy conf because tamp_compressor_init zeroes the struct before reading it.
+    TampConf conf = compressor->conf;
+    // Clear use_custom_dictionary so init re-initializes the dictionary with the
+    // default, matching what the decompressor does on a double-FLUSH reset.
+    conf.use_custom_dictionary = false;
+    res = tamp_compressor_init(compressor, &conf, compressor->window);
+    compressor->bit_buffer = 0;
+    compressor->bit_buffer_pos = 0;
+
+    return res;
 }
 
 #if TAMP_STREAM

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -648,14 +648,27 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_compress_cb(TampCompressor* compress
 #pragma GCC push_options
 #pragma GCC optimize("-fno-tree-pre")
 #endif
-tamp_res tamp_compressor_flush(TampCompressor* compressor, unsigned char* output, size_t output_size,
-                               size_t* output_written_size, bool write_token) {
+/**
+ * @brief Internal flush implementation.
+ *
+ * Same as tamp_compressor_flush, but additionally reports whether a FLUSH
+ * token was written to the output stream. Used by reset_dictionary to
+ * determine the exact number of additional FLUSHes needed.
+ *
+ * @param[out] flush_token_written Set to true if a FLUSH token was written. May be NULL.
+ */
+static TAMP_NOINLINE tamp_res tamp_compressor_flush_impl(TampCompressor* compressor, unsigned char* output,
+                                                         size_t output_size, size_t* output_written_size,
+                                                         bool write_token, bool* flush_token_written) {
     tamp_res res;
     size_t chunk_output_written_size;
     size_t output_written_size_proxy;
+    bool flush_token_written_proxy;
 
     if (!output_written_size) output_written_size = &output_written_size_proxy;
+    if (!flush_token_written) flush_token_written = &flush_token_written_proxy;
     *output_written_size = 0;
+    *flush_token_written = false;
 
 flush_check:
     // Flush pending bits before checking for more work
@@ -706,6 +719,7 @@ flush_done:
         // end up accidentally writing multiple FLUSH tokens.
         if (TAMP_UNLIKELY(output_size < 2)) return TAMP_OUTPUT_FULL;
         write_to_bit_buffer(compressor, FLUSH_CODE, 9);
+        *flush_token_written = true;
     }
 
     // At this point, up to 16 bits may remain in the compressor->bit_buffer
@@ -722,6 +736,11 @@ flush_done:
     }
 
     return res;
+}
+
+tamp_res tamp_compressor_flush(TampCompressor* compressor, unsigned char* output, size_t output_size,
+                               size_t* output_written_size, bool write_token) {
+    return tamp_compressor_flush_impl(compressor, output, output_size, output_written_size, write_token, NULL);
 }
 #if TAMP_HAS_GCC_OPTIMIZE
 #pragma GCC pop_options

--- a/tamp/_c_src/tamp/compressor.h
+++ b/tamp/_c_src/tamp/compressor.h
@@ -179,6 +179,30 @@ tamp_res tamp_compressor_flush(TampCompressor *compressor, unsigned char *output
                                size_t *output_written_size, bool write_token);
 
 /**
+ * @brief Reset the compressor dictionary and internal state.
+ *
+ * Writes a double-FLUSH token sequence to signal dictionary re-initialization
+ * to the decompressor, then resets the window and all internal compression state.
+ *
+ * The compressor continues to use the same configuration (window, literal, etc.)
+ * but starts fresh with a re-initialized dictionary.
+ *
+ * The compressor must have been initialized with conf->dictionary_reset set.
+ * This causes the header to include the more_header flag, which old decompressors
+ * will reject rather than silently producing corrupt output.
+ *
+ * @param[in,out] compressor TampCompressor object to reset.
+ * @param[out] output Pointer to a pre-allocated buffer to hold output data.
+ * @param[in] output_size Size of the pre-allocated output buffer.
+ * @param[out] output_written_size Number of bytes written to output. May be NULL.
+ *
+ * @return Tamp Status Code. Can return TAMP_OK, TAMP_OUTPUT_FULL, or
+ *         TAMP_INVALID_CONF if dictionary_reset was not set at init.
+ */
+tamp_res tamp_compressor_reset_dictionary(TampCompressor *compressor, unsigned char *output, size_t output_size,
+                                          size_t *output_written_size);
+
+/**
  * Callback-variant of tamp_compressor_compress.
  *
  * @param[in] callback User-provided function to be called every compression-cycle.

--- a/tamp/_c_src/tamp/compressor.h
+++ b/tamp/_c_src/tamp/compressor.h
@@ -58,6 +58,11 @@ typedef struct TampCompressor {
 /**
  * @brief Initialize Tamp Compressor object.
  *
+ * When conf->append is true, writes a FLUSH token to the internal bit buffer
+ * instead of a header, enabling append-after-reboot on streams with
+ * dictionary_reset enabled. Requires dictionary_reset=true and
+ * use_custom_dictionary=false.
+ *
  * @param[out] compressor Object to initialize.
  * @param[in] conf Compressor configuration. Set to NULL for default (window=10, literal=8).
  * @param[in] window Pre-allocated window buffer. Size must agree with conf->window.
@@ -201,29 +206,6 @@ tamp_res tamp_compressor_flush(TampCompressor *compressor, unsigned char *output
  */
 tamp_res tamp_compressor_reset_dictionary(TampCompressor *compressor, unsigned char *output, size_t output_size,
                                           size_t *output_written_size);
-
-/**
- * @brief Initialize compressor for appending to an existing stream.
- *
- * Initializes the compressor identically to tamp_compressor_init, but writes
- * a FLUSH token to the internal bit buffer instead of a header. When the
- * original stream ended with a flush (which is guaranteed when dictionary_reset
- * is enabled), the subsequent flush/compress call creates a double-FLUSH
- * sequence that tells the decompressor to reset its dictionary.
- *
- * This enables resuming compression on an existing stream without persisting
- * compressor state (e.g., across reboots).
- *
- * conf->dictionary_reset must be true and conf->use_custom_dictionary must be false.
- *
- * @param[out] compressor Object to initialize.
- * @param[in] conf Compressor configuration. Must match the original stream's configuration.
- * @param[in] window Pre-allocated window buffer.
- *
- * @return Tamp Status Code. Returns TAMP_INVALID_CONF if dictionary_reset is
- *         not set or use_custom_dictionary is set.
- */
-tamp_res tamp_compressor_init_append(TampCompressor *compressor, const TampConf *conf, unsigned char *window);
 
 /**
  * Callback-variant of tamp_compressor_compress.

--- a/tamp/_c_src/tamp/compressor.h
+++ b/tamp/_c_src/tamp/compressor.h
@@ -203,6 +203,29 @@ tamp_res tamp_compressor_reset_dictionary(TampCompressor *compressor, unsigned c
                                           size_t *output_written_size);
 
 /**
+ * @brief Initialize compressor for appending to an existing stream.
+ *
+ * Initializes the compressor identically to tamp_compressor_init, but writes
+ * a FLUSH token to the internal bit buffer instead of a header. When the
+ * original stream ended with a flush (which is guaranteed when dictionary_reset
+ * is enabled), the subsequent flush/compress call creates a double-FLUSH
+ * sequence that tells the decompressor to reset its dictionary.
+ *
+ * This enables resuming compression on an existing stream without persisting
+ * compressor state (e.g., across reboots).
+ *
+ * conf->dictionary_reset must be true and conf->use_custom_dictionary must be false.
+ *
+ * @param[out] compressor Object to initialize.
+ * @param[in] conf Compressor configuration. Must match the original stream's configuration.
+ * @param[in] window Pre-allocated window buffer.
+ *
+ * @return Tamp Status Code. Returns TAMP_INVALID_CONF if dictionary_reset is
+ *         not set or use_custom_dictionary is set.
+ */
+tamp_res tamp_compressor_init_append(TampCompressor *compressor, const TampConf *conf, unsigned char *window);
+
+/**
  * Callback-variant of tamp_compressor_compress.
  *
  * @param[in] callback User-provided function to be called every compression-cycle.

--- a/tamp/_c_src/tamp/decompressor.c
+++ b/tamp/_c_src/tamp/decompressor.c
@@ -256,13 +256,21 @@ tamp_res tamp_decompressor_read_header(TampConf* conf, const unsigned char* inpu
                                        size_t* input_consumed_size) {
     if (input_consumed_size) (*input_consumed_size) = 0;
     if (input_size == 0) return TAMP_INPUT_EXHAUSTED;
-    if (input[0] & 0x1) return TAMP_INVALID_CONF;  // Currently only a single header byte is supported.
-    if (input_consumed_size) (*input_consumed_size)++;
+
+    // Validate all header bytes before mutating conf.
+    size_t header_size = 1 + (input[0] & 0x1);
+    if (input_size < header_size) return TAMP_INPUT_EXHAUSTED;
+    // All bits in byte 2 are reserved for future use; reject if any are set.
+    if (header_size >= 2 && input[1]) return TAMP_INVALID_CONF;
 
     conf->window = ((input[0] >> 5) & 0x7) + 8;
     conf->literal = ((input[0] >> 3) & 0x3) + 5;
     conf->use_custom_dictionary = ((input[0] >> 2) & 0x1);
     conf->extended = ((input[0] >> 1) & 0x1);
+    // more_header (byte 1 bit 0) implies dictionary_reset.
+    conf->dictionary_reset = input[0] & 0x1;
+
+    if (input_consumed_size) (*input_consumed_size) += header_size;
 
     return TAMP_OK;
 }
@@ -275,7 +283,8 @@ tamp_res tamp_decompressor_read_header(TampConf* conf, const unsigned char* inpu
 static TAMP_OPTIMIZE_SIZE tamp_res tamp_decompressor_populate_from_conf(TampDecompressor* decompressor,
                                                                         uint8_t conf_window, uint8_t conf_literal,
                                                                         uint8_t conf_use_custom_dictionary,
-                                                                        uint8_t conf_extended) {
+                                                                        uint8_t conf_extended,
+                                                                        uint8_t conf_dictionary_reset) {
     if (conf_window < 8 || conf_window > 15) return TAMP_INVALID_CONF;
     if (conf_literal < 5 || conf_literal > 8) return TAMP_INVALID_CONF;
     if (conf_window > decompressor->window_bits_max) return TAMP_INVALID_CONF;
@@ -287,6 +296,7 @@ static TAMP_OPTIMIZE_SIZE tamp_res tamp_decompressor_populate_from_conf(TampDeco
     decompressor->min_pattern_size = tamp_compute_min_pattern_size(conf_window, conf_literal);
     decompressor->configured = true;
     decompressor->conf_extended = conf_extended;
+    decompressor->conf_dictionary_reset = conf_dictionary_reset;
 #if !TAMP_EXTENDED_DECOMPRESS
     if (conf_extended) return TAMP_INVALID_CONF;  // Extended stream but extended support not compiled in
 #endif
@@ -306,7 +316,7 @@ tamp_res tamp_decompressor_init(TampDecompressor* decompressor, const TampConf* 
     decompressor->window_bits_max = window_bits;
     if (conf) {
         res = tamp_decompressor_populate_from_conf(decompressor, conf->window, conf->literal,
-                                                   conf->use_custom_dictionary, conf->extended);
+                                                   conf->use_custom_dictionary, conf->extended, conf->dictionary_reset);
     }
 
     return res;
@@ -349,19 +359,40 @@ tamp_res tamp_decompressor_decompress_cb(TampDecompressor* decompressor, unsigne
     *input_consumed_size = 0;
     *output_written_size = 0;
 
-    if (!decompressor->configured) {
-        // Read in header
-        size_t header_consumed_size;
+    if (TAMP_UNLIKELY(!decompressor->configured)) {
+        // Implicit header read: assemble available header bytes into a
+        // stack buffer, then delegate to tamp_decompressor_read_header.
+        unsigned char header_buf[2];
+        uint8_t n = decompressor->header_bytes_read;
+
+        // Prepend any previously stashed byte.
+        if (n) header_buf[0] = decompressor->stashed_header_byte;
+
+        // Append new bytes from input.
+        while (n < sizeof(header_buf) && input != input_end) {
+            header_buf[n++] = *input++;
+            (*input_consumed_size)++;
+        }
+
+        size_t header_consumed;
         TampConf conf;
-        res = tamp_decompressor_read_header(&conf, input, input_end - input, &header_consumed_size);
+        res = tamp_decompressor_read_header(&conf, header_buf, n, &header_consumed);
+        if (res == TAMP_INPUT_EXHAUSTED) {
+            // Stash what we have so far for the next call.
+            if (n) decompressor->stashed_header_byte = header_buf[0];
+            decompressor->header_bytes_read = n;
+            return TAMP_INPUT_EXHAUSTED;
+        }
         if (res != TAMP_OK) return res;
+
+        // Return any bytes read_header didn't consume back to the input stream.
+        size_t excess = n - header_consumed;
+        input -= excess;
+        (*input_consumed_size) -= excess;
 
         res = tamp_decompressor_populate_from_conf(decompressor, conf.window, conf.literal, conf.use_custom_dictionary,
-                                                   conf.extended);
+                                                   conf.extended, conf.dictionary_reset);
         if (res != TAMP_OK) return res;
-
-        input += header_consumed_size;
-        (*input_consumed_size) += header_consumed_size;
     }
 
     // Cache bitfield values in local variables for faster access
@@ -409,6 +440,7 @@ tamp_res tamp_decompressor_decompress_cb(TampDecompressor* decompressor, unsigne
         // Hint that patterns are more likely than literals
         if (TAMP_UNLIKELY(decompressor->bit_buffer >> 31)) {
             // is literal
+            if (TAMP_UNLIKELY(decompressor->last_was_flush)) decompressor->last_was_flush = 0;
             if (TAMP_UNLIKELY(decompressor->bit_buffer_pos < (1 + conf_literal))) return TAMP_INPUT_EXHAUSTED;
             decompressor->bit_buffer <<= 1;  // shift out the is_literal flag
 
@@ -446,8 +478,17 @@ tamp_res tamp_decompressor_decompress_cb(TampDecompressor* decompressor, unsigne
                 decompressor->bit_buffer = bit_buffer << (bit_buffer_pos & 7);
                 decompressor->bit_buffer_pos =
                     bit_buffer_pos & ~7;  // Round bit_buffer_pos down to nearest multiple of 8.
+                if (decompressor->conf_dictionary_reset && decompressor->last_was_flush) {
+                    // Double-FLUSH: reset dictionary.
+                    decompressor->window_pos = 0;
+                    tamp_initialize_dictionary(decompressor->window, (size_t)1 << conf_window,
+                                               decompressor->conf_extended ? conf_literal : 8);
+                }
+                decompressor->last_was_flush = 1;
                 continue;
             }
+
+            if (TAMP_UNLIKELY(decompressor->last_was_flush)) decompressor->last_was_flush = 0;
 
 #if TAMP_EXTENDED_DECOMPRESS
             /* Check for extended symbols (RLE=12, extended match=13).

--- a/tamp/_c_src/tamp/decompressor.c
+++ b/tamp/_c_src/tamp/decompressor.c
@@ -393,6 +393,7 @@ tamp_res tamp_decompressor_decompress_cb(TampDecompressor* decompressor, unsigne
         res = tamp_decompressor_populate_from_conf(decompressor, conf.window, conf.literal, conf.use_custom_dictionary,
                                                    conf.extended, conf.dictionary_reset);
         if (res != TAMP_OK) return res;
+        decompressor->skip_bytes = 0;  // Clear stale stashed_header_byte (shares union storage)
     }
 
     // Cache bitfield values in local variables for faster access

--- a/tamp/_c_src/tamp/decompressor.h
+++ b/tamp/_c_src/tamp/decompressor.h
@@ -41,7 +41,8 @@ typedef struct {
     uint8_t conf_literal : 4;           // Literal bits from config
     uint8_t min_pattern_size : 2;       // Minimum pattern size, 2 or 3
     uint8_t conf_extended : 1;          // Extended format enabled (from header)
-    uint8_t conf_dictionary_reset : 1;  // Stream may contain double-FLUSH dictionary resets (signaled by header byte 1 bit 0 / more_header; header byte 2 is reserved/zero)
+    uint8_t conf_dictionary_reset : 1;  // Stream may contain double-FLUSH dictionary resets (from header byte 1 bit [0]
+                                        // / more_header)
 
     /* COLD: rarely accessed (init or edge cases).
      * Bitfields save space; add new cold fields here. */

--- a/tamp/_c_src/tamp/decompressor.h
+++ b/tamp/_c_src/tamp/decompressor.h
@@ -41,7 +41,7 @@ typedef struct {
     uint8_t conf_literal : 4;           // Literal bits from config
     uint8_t min_pattern_size : 2;       // Minimum pattern size, 2 or 3
     uint8_t conf_extended : 1;          // Extended format enabled (from header)
-    uint8_t conf_dictionary_reset : 1;  // Stream may contain double-FLUSH dictionary resets (from header byte 2)
+    uint8_t conf_dictionary_reset : 1;  // Stream may contain double-FLUSH dictionary resets (signaled by header byte 1 bit 0 / more_header; header byte 2 is reserved/zero)
 
     /* COLD: rarely accessed (init or edge cases).
      * Bitfields save space; add new cold fields here. */

--- a/tamp/_c_src/tamp/decompressor.h
+++ b/tamp/_c_src/tamp/decompressor.h
@@ -37,16 +37,22 @@ typedef struct {
 #endif
 
     /* WARM: read once at start of decompress, cached in locals */
-    uint8_t conf_window : 4;       // Window bits from config
-    uint8_t conf_literal : 4;      // Literal bits from config
-    uint8_t min_pattern_size : 2;  // Minimum pattern size, 2 or 3
-    uint8_t conf_extended : 1;     // Extended format enabled (from header)
+    uint8_t conf_window : 4;            // Window bits from config
+    uint8_t conf_literal : 4;           // Literal bits from config
+    uint8_t min_pattern_size : 2;       // Minimum pattern size, 2 or 3
+    uint8_t conf_extended : 1;          // Extended format enabled (from header)
+    uint8_t conf_dictionary_reset : 1;  // Stream may contain double-FLUSH dictionary resets (from header byte 2)
 
     /* COLD: rarely accessed (init or edge cases).
      * Bitfields save space; add new cold fields here. */
-    uint8_t skip_bytes;           // For output-buffer-limited resumption (v2 needs >4 bits)
-    uint8_t window_bits_max : 4;  // Max window bits buffer can hold
-    uint8_t configured : 1;       // Whether config has been set
+    union {
+        uint8_t skip_bytes;           // After configured: output-buffer-limited resumption (v2 needs >4 bits)
+        uint8_t stashed_header_byte;  // Before configured: first header byte when waiting for second
+    };
+    uint8_t window_bits_max : 4;    // Max window bits buffer can hold
+    uint8_t configured : 1;         // Whether config has been set (authoritative "header complete" flag)
+    uint8_t header_bytes_read : 2;  // Before configured: header bytes consumed so far
+    uint8_t last_was_flush : 1;     // Previous token was FLUSH (for double-FLUSH dictionary reset detection)
 } TampDecompressor;
 
 /**

--- a/tamp/compressor.py
+++ b/tamp/compressor.py
@@ -64,8 +64,10 @@ class _BitWriter:
 
     def flush(self, write_token=True):
         bytes_written = 0
+        self._flush_token_written = False
         if self.bit_pos > 0 and write_token:
             bytes_written += self.write(_FLUSH_CODE, 9)
+            self._flush_token_written = True
 
         while self.bit_pos > 0:
             byte = (self.buffer >> 24) & 0xFF
@@ -144,6 +146,7 @@ class Compressor:
         dictionary: Optional[bytearray] = None,
         lazy_matching: bool = False,
         extended: bool = True,
+        dictionary_reset: bool = False,
     ):
         """
         Parameters
@@ -175,18 +178,12 @@ class Compressor:
         self.literal_bits = literal
         self.min_pattern_size = compute_min_pattern_size(window, literal)
         self.extended: bool = extended
-
-        self._rle_count = 0
+        self.dictionary_reset: bool = dictionary_reset
 
         # "+1" Because a RLE of 1 is not valid.
         self._rle_max_size = (14 << _LEADING_RLE_HUFFMAN_BITS) + (1 << _LEADING_RLE_HUFFMAN_BITS) + 1
 
-        self._extended_match_count = 0
-        self._extended_match_position = 0
-
         self.lazy_matching = lazy_matching
-        self._cached_match_index = -1
-        self._cached_match_size = 0
 
         if not hasattr(f, "write"):  # It's probably a path-like object.
             f = open(str(f), "wb")
@@ -210,11 +207,7 @@ class Compressor:
 
         self.literal_flag = 1 << self.literal_bits
 
-        self._window_buffer = _RingBuffer(
-            buffer=dictionary if dictionary else initialize_dictionary(1 << window, literal=literal if extended else 8),
-        )
-
-        self._input_buffer = deque(maxlen=16)  # matching the C implementation
+        self._reset_state(dictionary)
 
         # Callbacks for debugging/metric collection; can be externally set.
         self.match_cb = None
@@ -231,7 +224,26 @@ class Compressor:
         self._bit_writer.write(literal - 5, 2, flush=False)
         self._bit_writer.write(bool(dictionary), 1, flush=False)
         self._bit_writer.write(self.extended, 1, flush=False)
-        self._bit_writer.write(0, 1, flush=False)  # No other header bytes
+        self._bit_writer.write(1 if dictionary_reset else 0, 1, flush=False)  # more_headers (implies dictionary_reset)
+        if dictionary_reset:
+            # Header byte 2: all bits reserved for future use, currently all zero.
+            self._bit_writer.write(0, 8, flush=False)
+
+    def _reset_state(self, dictionary=None):
+        """Reset mutable compression state and (re-)initialize the dictionary."""
+        self._window_buffer = _RingBuffer(
+            buffer=(
+                dictionary
+                if dictionary
+                else initialize_dictionary(1 << self.window_bits, literal=self.literal_bits if self.extended else 8)
+            ),
+        )
+        self._input_buffer = deque(maxlen=16)
+        self._rle_count = 0
+        self._extended_match_count = 0
+        self._extended_match_position = 0
+        self._cached_match_index = -1
+        self._cached_match_size = 0
 
     def _validate_no_match_overlap(self, write_pos, match_index, match_size):
         """Check if writing a single byte will overlap with a future match section."""
@@ -536,6 +548,51 @@ class Compressor:
 
         bytes_written_flush = self._bit_writer.flush(write_token=write_token)
         bytes_written += bytes_written_flush
+        return bytes_written
+
+    def reset_dictionary(self) -> int:
+        """Reset the dictionary and internal state, writing a double-FLUSH signal.
+
+        This allows the decompressor to re-initialize its dictionary at the
+        corresponding point in the stream. Useful for long streams where
+        the data characteristics change significantly.
+
+        Returns
+        -------
+        int
+            Number of compressed bytes written.
+
+        Raises
+        ------
+        ValueError
+            If the compressor was not initialized with ``dictionary_reset=True``.
+        """
+        if not self.dictionary_reset:
+            raise ValueError("Compressor was not initialized with dictionary_reset=True")
+
+        bytes_written = 0
+
+        # Flush all pending data with write_token=True.
+        bytes_written += self.flush(write_token=True)
+
+        # We need exactly 2 consecutive FLUSHes in the stream.
+        # If flush already wrote one, we need 1 more; otherwise 2.
+        flushes_needed = 1 if self._bit_writer._flush_token_written else 2
+        for _ in range(flushes_needed):
+            bytes_written += self._bit_writer.write(_FLUSH_CODE, 9)
+            # Pad to byte boundary
+            if self._bit_writer.bit_pos > 0:
+                byte = (self._bit_writer.buffer >> 24) & 0xFF
+                self._bit_writer.f.write(byte.to_bytes(1, "big"))
+                self._bit_writer.bit_pos = 0
+                self._bit_writer.buffer = 0
+                bytes_written += 1
+
+        # Re-initialize dictionary with default and reset all mutable state,
+        # matching what the decompressor does on a double-FLUSH reset
+        # (even if originally using a custom dictionary).
+        self._reset_state()
+
         return bytes_written
 
     def close(self) -> int:

--- a/tamp/compressor.py
+++ b/tamp/compressor.py
@@ -623,7 +623,9 @@ class Compressor:
             Number of compressed bytes flushed to disk.
         """
         bytes_written = 0
-        bytes_written += self.flush(write_token=False)
+        # When dictionary_reset is enabled, always end with a FLUSH token
+        # so that a future append-mode compressor can form a double-FLUSH.
+        bytes_written += self.flush(write_token=self.dictionary_reset)
         self._bit_writer.close()
         return bytes_written
 

--- a/tamp/compressor.py
+++ b/tamp/compressor.py
@@ -62,10 +62,10 @@ class _BitWriter:
                 bytes_written += 1
         return bytes_written
 
-    def flush(self, write_token=True):
+    def flush(self, write_token=True, force_token=False):
         bytes_written = 0
         self._flush_token_written = False
-        if self.bit_pos > 0 and write_token:
+        if write_token and (self.bit_pos > 0 or force_token):
             bytes_written += self.write(_FLUSH_CODE, 9)
             self._flush_token_written = True
 
@@ -147,6 +147,7 @@ class Compressor:
         lazy_matching: bool = False,
         extended: bool = True,
         dictionary_reset: bool = False,
+        append: bool = False,
     ):
         """
         Parameters
@@ -173,6 +174,11 @@ class Compressor:
             first be initialized with :func:`~tamp.initialize_dictionary`
         lazy_matching: bool
             Use roughly 50% more cpu to get 0~2% better compression.
+        append: bool
+            Initialize for appending to an existing stream instead of writing a
+            header. Writes a FLUSH token that, combined with the previous stream's
+            trailing FLUSH, triggers a dictionary reset in the decompressor.
+            Requires ``dictionary_reset=True``.
         """
         self.window_bits = window
         self.literal_bits = literal
@@ -219,15 +225,28 @@ class Compressor:
         # For debugging: how many uncompressed bytes have we consumed so far.
         self.input_index = 0
 
-        # Write header
-        self._bit_writer.write(window - 8, 3, flush=False)
-        self._bit_writer.write(literal - 5, 2, flush=False)
-        self._bit_writer.write(bool(dictionary), 1, flush=False)
-        self._bit_writer.write(self.extended, 1, flush=False)
-        self._bit_writer.write(1 if dictionary_reset else 0, 1, flush=False)  # more_headers (implies dictionary_reset)
-        if dictionary_reset:
-            # Header byte 2: all bits reserved for future use, currently all zero.
-            self._bit_writer.write(0, 8, flush=False)
+        if append:
+            if not dictionary_reset:
+                raise ValueError("append=True requires dictionary_reset=True")
+            if dictionary:
+                raise ValueError("append=True cannot use a custom dictionary")
+            # Write a FLUSH token to the bit buffer instead of a header.
+            # It will be flushed out naturally by the next compress/flush call.
+            # Combined with the previous stream's trailing FLUSH, this triggers
+            # a dictionary reset in the decompressor.
+            self._bit_writer.write(_FLUSH_CODE, 9, flush=False)
+        else:
+            # Write header
+            self._bit_writer.write(window - 8, 3, flush=False)
+            self._bit_writer.write(literal - 5, 2, flush=False)
+            self._bit_writer.write(bool(dictionary), 1, flush=False)
+            self._bit_writer.write(self.extended, 1, flush=False)
+            self._bit_writer.write(
+                1 if dictionary_reset else 0, 1, flush=False
+            )  # more_headers (implies dictionary_reset)
+            if dictionary_reset:
+                # Header byte 2: all bits reserved for future use, currently all zero.
+                self._bit_writer.write(0, 8, flush=False)
 
     def _reset_state(self, dictionary=None):
         """Reset mutable compression state and (re-)initialize the dictionary."""
@@ -546,7 +565,7 @@ class Compressor:
             self._cached_match_index = -1
             self._cached_match_size = 0
 
-        bytes_written_flush = self._bit_writer.flush(write_token=write_token)
+        bytes_written_flush = self._bit_writer.flush(write_token=write_token, force_token=self.dictionary_reset)
         bytes_written += bytes_written_flush
         return bytes_written
 

--- a/tamp/compressor.py
+++ b/tamp/compressor.py
@@ -41,6 +41,7 @@ class _BitWriter:
         self.f = f
         self.buffer = 0  # Basically a uint32
         self.bit_pos = 0
+        self._flush_token_written = False
 
     def write_huffman_and_literal_flag(self, pattern_size):
         # pattern_size in range [0, 14]
@@ -230,11 +231,12 @@ class Compressor:
                 raise ValueError("append=True requires dictionary_reset=True")
             if dictionary:
                 raise ValueError("append=True cannot use a custom dictionary")
-            # Write a FLUSH token to the bit buffer instead of a header.
-            # It will be flushed out naturally by the next compress/flush call.
-            # Combined with the previous stream's trailing FLUSH, this triggers
-            # a dictionary reset in the decompressor.
+            # Write a FLUSH token instead of a header. Pad to byte boundary
+            # so subsequent compressed data starts cleanly after the decompressor
+            # discards FLUSH padding bits. Combined with the previous stream's
+            # trailing FLUSH, this triggers a dictionary reset in the decompressor.
             self._bit_writer.write(_FLUSH_CODE, 9, flush=False)
+            self._bit_writer.bit_pos = 16  # Pad to 2 bytes (bits are already zero)
         else:
             # Write header
             self._bit_writer.write(window - 8, 3, flush=False)

--- a/tamp/ctamp.pxd
+++ b/tamp/ctamp.pxd
@@ -8,6 +8,7 @@ cdef extern from "tamp/common.h":
         bool use_custom_dictionary
         bool extended  # Extended format (RLE, extended match). Read from header bit [1].
         bool dictionary_reset  # Stream may contain double-FLUSH dictionary resets. Header byte 2 bit [7].
+        bool append  # Initialize for appending to an existing stream (FLUSH instead of header).
         # The lazy_matching field is conditionally compiled based on TAMP_LAZY_MATCHING
         # We declare it here, but accessing it when the macro is disabled will cause compile errors
         # This is handled in the Cython code by always setting it when the struct is initialized
@@ -74,11 +75,6 @@ cdef extern from "tamp/compressor.h":
             size_t *output_written_size
             )
 
-    tamp_res tamp_compressor_init_append(
-            TampCompressor *compressor,
-            const TampConf *conf,
-            unsigned char *window,
-            )
 
 
 cdef extern from "tamp/decompressor.h":

--- a/tamp/ctamp.pxd
+++ b/tamp/ctamp.pxd
@@ -7,7 +7,7 @@ cdef extern from "tamp/common.h":
         int literal
         bool use_custom_dictionary
         bool extended  # Extended format (RLE, extended match). Read from header bit [1].
-        bool dictionary_reset  # Stream may contain double-FLUSH dictionary resets. Controlled via header byte 1 bit [0] (more_header); header byte 2 is reserved and must be 0.
+        bool dictionary_reset  # Stream may contain double-FLUSH dictionary resets. Implied by header byte 1 bit [0] (more_header).
         bool append  # Initialize for appending to an existing stream (FLUSH instead of header).
         # The lazy_matching field is conditionally compiled based on TAMP_LAZY_MATCHING
         # We declare it here, but accessing it when the macro is disabled will cause compile errors

--- a/tamp/ctamp.pxd
+++ b/tamp/ctamp.pxd
@@ -72,7 +72,13 @@ cdef extern from "tamp/compressor.h":
             unsigned char *output,
             size_t output_size,
             size_t *output_written_size
-            );
+            )
+
+    tamp_res tamp_compressor_init_append(
+            TampCompressor *compressor,
+            const TampConf *conf,
+            unsigned char *window,
+            )
 
 
 cdef extern from "tamp/decompressor.h":

--- a/tamp/ctamp.pxd
+++ b/tamp/ctamp.pxd
@@ -66,14 +66,14 @@ cdef extern from "tamp/compressor.h":
             const unsigned char *input,
             size_t input_size,
             size_t *input_consumed_size
-            )
+            );
 
     tamp_res tamp_compressor_reset_dictionary(
             TampCompressor *compressor,
             unsigned char *output,
             size_t output_size,
             size_t *output_written_size
-            )
+            );
 
 
 

--- a/tamp/ctamp.pxd
+++ b/tamp/ctamp.pxd
@@ -7,6 +7,7 @@ cdef extern from "tamp/common.h":
         int literal
         bool use_custom_dictionary
         bool extended  # Extended format (RLE, extended match). Read from header bit [1].
+        bool dictionary_reset  # Stream may contain double-FLUSH dictionary resets. Header byte 2 bit [7].
         # The lazy_matching field is conditionally compiled based on TAMP_LAZY_MATCHING
         # We declare it here, but accessing it when the macro is disabled will cause compile errors
         # This is handled in the Cython code by always setting it when the struct is initialized
@@ -64,6 +65,13 @@ cdef extern from "tamp/compressor.h":
             const unsigned char *input,
             size_t input_size,
             size_t *input_consumed_size
+            )
+
+    tamp_res tamp_compressor_reset_dictionary(
+            TampCompressor *compressor,
+            unsigned char *output,
+            size_t output_size,
+            size_t *output_written_size
             );
 
 

--- a/tamp/ctamp.pxd
+++ b/tamp/ctamp.pxd
@@ -7,7 +7,7 @@ cdef extern from "tamp/common.h":
         int literal
         bool use_custom_dictionary
         bool extended  # Extended format (RLE, extended match). Read from header bit [1].
-        bool dictionary_reset  # Stream may contain double-FLUSH dictionary resets. Header byte 2 bit [7].
+        bool dictionary_reset  # Stream may contain double-FLUSH dictionary resets. Controlled via header byte 1 bit [0] (more_header); header byte 2 is reserved and must be 0.
         bool append  # Initialize for appending to an existing stream (FLUSH instead of header).
         # The lazy_matching field is conditionally compiled based on TAMP_LAZY_MATCHING
         # We declare it here, but accessing it when the macro is disabled will cause compile errors

--- a/tamp/decompressor.py
+++ b/tamp/decompressor.py
@@ -188,7 +188,7 @@ class Decompressor:
             # Header byte 2: all bits reserved for future use.
             reserved = self._bit_reader.read(8)
             if reserved:
-                raise NotImplementedError
+                raise ValueError("Reserved bits in header byte 2 must be zero.")
 
         if uses_custom_dictionary and dictionary is None:
             raise ValueError

--- a/tamp/decompressor.py
+++ b/tamp/decompressor.py
@@ -182,8 +182,13 @@ class Decompressor:
         self.extended = self._bit_reader.read(1)
         more_header_bytes = self._bit_reader.read(1)
 
+        # more_header implies dictionary_reset
+        self.dictionary_reset = bool(more_header_bytes)
         if more_header_bytes:
-            raise NotImplementedError
+            # Header byte 2: all bits reserved for future use.
+            reserved = self._bit_reader.read(8)
+            if reserved:
+                raise NotImplementedError
 
         if uses_custom_dictionary and dictionary is None:
             raise ValueError
@@ -197,6 +202,8 @@ class Decompressor:
         )
 
         self.min_pattern_size = compute_min_pattern_size(self.window_bits, self.literal_bits)
+
+        self._last_was_flush = False
 
         # Used to store decoded bytes that do not currently fit in the output buffer.
         self.overflow = bytearray()
@@ -243,13 +250,24 @@ class Decompressor:
                     is_literal = self._bit_reader.read(1)
 
                     if is_literal:
+                        self._last_was_flush = False
                         string = bytes([self._bit_reader.read(self.literal_bits)])
                         self._window_buffer.write_bytes(string)
                     else:
                         match_size = self._bit_reader.read_huffman()
                         if match_size == _FLUSH:
                             self._bit_reader.clear()
+                            if self.dictionary_reset and self._last_was_flush:
+                                # Double-FLUSH: reset dictionary.
+                                self._window_buffer = _RingBuffer(
+                                    buffer=initialize_dictionary(
+                                        1 << self.window_bits,
+                                        literal=self.literal_bits if self.extended else 8,
+                                    ),
+                                )
+                            self._last_was_flush = True
                             continue
+                        self._last_was_flush = False
                         if self.extended and match_size > 11:
                             if match_size == _RLE_SYMBOL:
                                 rle_count = self._bit_reader.read_huffman()

--- a/tests/test_compressor_decompressor.py
+++ b/tests/test_compressor_decompressor.py
@@ -309,6 +309,204 @@ class TestCompressorAndDecompressor(unittest.TestCase):
                 d = Decompressor(f)
                 self.assertEqual(d.read(), data)
 
+    def test_reset_dictionary_basic(self):
+        """Compress data, flush, reset dictionary, compress more, decompress all."""
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, dictionary_reset=True)
+                c.write(tale_of_two_cities[:200])
+                c.flush(write_token=True)
+                c.reset_dictionary()
+                c.write(tale_of_two_cities[200:])
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, tale_of_two_cities)
+
+    def test_reset_dictionary_no_prior_flush(self):
+        """Reset dictionary directly without explicit flush first."""
+        data1 = b"Hello world! " * 20
+        data2 = b"Goodbye world! " * 20
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, dictionary_reset=True)
+                c.write(data1)
+                c.reset_dictionary()
+                c.write(data2)
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, data1 + data2)
+
+    def test_reset_dictionary_multiple_resets(self):
+        """Multiple resets in a single stream."""
+        data1 = b"Alpha " * 30
+        data2 = b"Beta " * 30
+        data3 = b"Gamma " * 30
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, dictionary_reset=True)
+                c.write(data1)
+                c.reset_dictionary()
+                c.write(data2)
+                c.reset_dictionary()
+                c.write(data3)
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, data1 + data2 + data3)
+
+    def test_reset_dictionary_immediate(self):
+        """Reset immediately after init (no data compressed yet)."""
+        data = tale_of_two_cities
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, dictionary_reset=True)
+                c.reset_dictionary()
+                c.write(data)
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, data)
+
+    def test_reset_dictionary_extended(self):
+        """Reset with extended=True."""
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, extended=True, dictionary_reset=True)
+                c.write(tale_of_two_cities[:200])
+                c.flush(write_token=True)
+                c.reset_dictionary()
+                c.write(tale_of_two_cities[200:])
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, tale_of_two_cities)
+
+    def test_reset_dictionary_lazy_matching(self):
+        """Reset with extended=True and lazy_matching=True."""
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            if Compressor is NativeCompressor:
+                continue
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, extended=True, lazy_matching=True, dictionary_reset=True)
+                c.write(tale_of_two_cities[:200])
+                c.flush(write_token=True)
+                c.reset_dictionary()
+                c.write(tale_of_two_cities[200:])
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, tale_of_two_cities)
+
+    def test_reset_dictionary_small_window(self):
+        """Reset with smallest window size (window=8)."""
+        data1 = tale_of_two_cities[:100]
+        data2 = tale_of_two_cities[100:200]
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, window=8, dictionary_reset=True)
+                c.write(data1)
+                c.reset_dictionary()
+                c.write(data2)
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, data1 + data2)
+
+    def test_reset_dictionary_different_literals(self):
+        """Reset with different literal values (5, 6, 7)."""
+        for literal in (5, 6, 7):
+            n_bits = literal
+            data1 = bytearray(random.randint(0, (1 << n_bits) - 1) for _ in range(200))
+            data2 = bytearray(random.randint(0, (1 << n_bits) - 1) for _ in range(200))
+            for Compressor, Decompressor in walk_compressors_decompressors():
+                with BytesIO() as f, self.subTest(literal=literal, Compressor=Compressor, Decompressor=Decompressor):
+                    c = Compressor(f, literal=literal, dictionary_reset=True)
+                    c.write(data1)
+                    c.reset_dictionary()
+                    c.write(data2)
+                    c.flush(write_token=False)
+
+                    f.seek(0)
+                    d = Decompressor(f)
+                    actual = d.read()
+
+                    self.assertEqual(actual, data1 + data2)
+
+    def test_reset_dictionary_rle_boundary(self):
+        """Reset after compressing RLE-heavy data."""
+        data1 = b"A" * 200
+        data2 = b"The quick brown fox jumps over the lazy dog. " * 5
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, extended=True, dictionary_reset=True)
+                c.write(data1)
+                c.reset_dictionary()
+                c.write(data2)
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+
+                self.assertEqual(actual, data1 + data2)
+
+    def test_reset_dictionary_cross_impl(self):
+        """Cross-implementation: compress with Py, decompress with C (and vice versa)."""
+        if PyCompressor is None or CCompressor is None or PyDecompressor is None or CDecompressor is None:
+            self.skipTest("Need both Py and C implementations")
+
+        data1 = tale_of_two_cities[:200]
+        data2 = tale_of_two_cities[200:]
+
+        # Py compress, C decompress
+        with BytesIO() as f, self.subTest(compress="Py", decompress="C"):
+            c = PyCompressor(f, dictionary_reset=True)
+            c.write(data1)
+            c.reset_dictionary()
+            c.write(data2)
+            c.flush(write_token=False)
+
+            f.seek(0)
+            d = CDecompressor(f)
+            actual = d.read()
+            self.assertEqual(actual, tale_of_two_cities)
+
+        # C compress, Py decompress
+        with BytesIO() as f, self.subTest(compress="C", decompress="Py"):
+            c = CCompressor(f, dictionary_reset=True)
+            c.write(data1)
+            c.reset_dictionary()
+            c.write(data2)
+            c.flush(write_token=False)
+
+            f.seek(0)
+            d = PyDecompressor(f)
+            actual = d.read()
+            self.assertEqual(actual, tale_of_two_cities)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_compressor_decompressor.py
+++ b/tests/test_compressor_decompressor.py
@@ -507,6 +507,28 @@ class TestCompressorAndDecompressor(unittest.TestCase):
             actual = d.read()
             self.assertEqual(actual, tale_of_two_cities)
 
+    def test_append_mode_roundtrip(self):
+        """Append mode: two compressor sessions, concatenated output, single decompress."""
+        data1 = b"Hello world! Hello world! Hello world! "
+        data2 = b"Goodbye world! Goodbye world! Goodbye world! "
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                # Session 1: compress with dictionary_reset, close (emits trailing FLUSH)
+                c1 = Compressor(f, dictionary_reset=True)
+                c1.write(data1)
+                c1.close()
+
+                # Session 2: append mode compressor
+                c2 = Compressor(f, dictionary_reset=True, append=True)
+                c2.write(data2)
+                c2.close()
+
+                # Decompress the full concatenated stream
+                f.seek(0)
+                d = Decompressor(f)
+                actual = d.read()
+                self.assertEqual(actual, data1 + data2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -35,7 +35,7 @@ EMCC_FLAGS = -O3 \
 	--no-entry \
 	-s WASM=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \
-	-s EXPORTED_FUNCTIONS='["_malloc", "_free", "_tamp_compressor_init", "_tamp_compressor_flush", "_tamp_compressor_sink", "_tamp_compressor_poll", "_tamp_compressor_full", "_tamp_compressor_sizeof", "_tamp_decompressor_init", "_tamp_decompressor_decompress_cb", "_tamp_decompressor_read_header", "_tamp_decompressor_sizeof", "_tamp_compute_min_pattern_size", "_tamp_initialize_dictionary", "_tamp_conf_sizeof"]' \
+	-s EXPORTED_FUNCTIONS='["_malloc", "_free", "_tamp_compressor_init", "_tamp_compressor_flush", "_tamp_compressor_sink", "_tamp_compressor_poll", "_tamp_compressor_full", "_tamp_compressor_reset_dictionary", "_tamp_compressor_sizeof", "_tamp_decompressor_init", "_tamp_decompressor_decompress_cb", "_tamp_decompressor_read_header", "_tamp_decompressor_sizeof", "_tamp_compute_min_pattern_size", "_tamp_initialize_dictionary", "_tamp_conf_sizeof"]' \
 	-s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "getValue", "setValue", "UTF8ToString", "stringToUTF8", "addFunction", "removeFunction", "HEAPU8"]' \
 	-s MODULARIZE=1 \
 	-s EXPORT_NAME="TampModule" \

--- a/wasm/src/tamp.js
+++ b/wasm/src/tamp.js
@@ -591,8 +591,10 @@ export class TampDecompressor {
     throwOnError(headerResult, 'Header reading');
     if (headerResult !== TAMP_OK) {
       // TAMP_INPUT_EXHAUSTED: not enough bytes for header yet.
-      // Return 0 so caller retries with more data.
-      return 0;
+      // Stash the partial header bytes so the next decompress() call
+      // can combine them with fresh data and retry.
+      this.pendingInput = input.slice(0, headerBytes);
+      return input.length;
     }
 
     const headerBytesConsumed = this.module.getValue(this.inputConsumedPtr, 'i32');
@@ -705,9 +707,12 @@ export class TampDecompressor {
       const headerBytesConsumed = await this._readHeader(combinedInput);
       inputOffset += headerBytesConsumed;
 
-      // If we only have header data, store remaining for next call
-      if (inputOffset >= combinedInput.length) {
-        this.pendingInput = new Uint8Array(0);
+      // If header isn't complete yet or we only have header data, return early.
+      // When !headerRead, pendingInput was already set by _readHeader.
+      if (!this.headerRead || inputOffset >= combinedInput.length) {
+        if (this.headerRead) {
+          this.pendingInput = new Uint8Array(0);
+        }
         return new Uint8Array(0);
       }
     }

--- a/wasm/src/tamp.js
+++ b/wasm/src/tamp.js
@@ -124,6 +124,7 @@ export class TampCompressor {
       dictionary: null,
       extended: true,
       lazy_matching: false,
+      dictionary_reset: false,
       ...options,
     };
 
@@ -190,7 +191,8 @@ export class TampCompressor {
         ((this.options.literal & 0xf) << 4) |
         ((this.options.dictionary ? 1 : 0) << 8) |
         ((this.options.extended ? 1 : 0) << 9) |
-        ((this.options.lazy_matching ? 1 : 0) << 10);
+        ((this.options.dictionary_reset ? 1 : 0) << 10) |
+        ((this.options.lazy_matching ? 1 : 0) << 11);
       this.module.setValue(confPtr, confValue, 'i32');
 
       // Initialize compressor
@@ -452,6 +454,48 @@ export class TampCompressor {
   }
 
   /**
+   * Reset the compressor dictionary and internal state.
+   * Writes a double-FLUSH token sequence to signal dictionary re-initialization.
+   * @returns {Promise<Uint8Array>} - Output bytes written during reset
+   */
+  async resetDictionary() {
+    await this.initialize();
+
+    if (!this.compressorPtr) {
+      throw new Error('Compressor has been destroyed');
+    }
+
+    // Single allocation for output buffer (32 bytes) + output size pointer (4 bytes)
+    // Worst case: 23 (flush) + 4 (2x FLUSH) = 27 bytes
+    const outputBufSize = 32;
+    const totalAllocSize = outputBufSize + 4;
+    const basePtr = this.module._malloc(totalAllocSize);
+    if (basePtr === 0) {
+      throw new RangeError(`Failed to allocate reset memory (${totalAllocSize} bytes)`);
+    }
+
+    const outputPtr = basePtr;
+    const outputSizePtr = basePtr + outputBufSize;
+
+    try {
+      const result = this.module.ccall(
+        'tamp_compressor_reset_dictionary',
+        'number',
+        ['number', 'number', 'number', 'number'],
+        [this.compressorPtr, outputPtr, outputBufSize, outputSizePtr]
+      );
+
+      throwOnError(result, 'Reset dictionary');
+
+      const outputSize = this.module.getValue(outputSizePtr, 'i32');
+      const resetOutput = new Uint8Array(this.module.HEAPU8.buffer, outputPtr, outputSize).slice();
+      return resetOutput;
+    } finally {
+      this.module._free(basePtr);
+    }
+  }
+
+  /**
    * Clean up allocated memory
    * @returns {void}
    */
@@ -500,8 +544,8 @@ export class TampDecompressor {
 
     const { conf: confStructSize } = wasmManager.structSizes;
 
-    // Allocate memory for header processing: conf + inputConsumed(4) + headerInput(1)
-    const initialSize = confStructSize + 4 + 1;
+    // Allocate memory for header processing: conf + inputConsumed(4) + headerInput(2)
+    const initialSize = confStructSize + 4 + 2;
     this.initialPtr = this.module._malloc(initialSize);
     if (this.initialPtr === 0) {
       throw new RangeError(`Failed to allocate initial memory (${initialSize} bytes)`);
@@ -526,18 +570,23 @@ export class TampDecompressor {
       return 0; // No data to process
     }
 
-    // Copy first byte for header reading
-    this.module.setValue(this.headerInputPtr, input[0], 'i8');
+    // Copy up to 2 bytes for header reading (second byte may be present)
+    const headerBytes = Math.min(input.length, 2);
+    for (let i = 0; i < headerBytes; i++) {
+      this.module.setValue(this.headerInputPtr + i, input[i], 'i8');
+    }
 
     // Read header to get configuration
     const headerResult = this.module.ccall(
       'tamp_decompressor_read_header',
       'number',
       ['number', 'number', 'number', 'number'],
-      [this.confPtr, this.headerInputPtr, 1, this.inputConsumedPtr]
+      [this.confPtr, this.headerInputPtr, headerBytes, this.inputConsumedPtr]
     );
 
     throwOnError(headerResult, 'Header reading');
+
+    const headerBytesConsumed = this.module.getValue(this.inputConsumedPtr, 'i32');
 
     // Extract configuration values from the header
     const confValue = this.module.getValue(this.confPtr, 'i32');
@@ -604,7 +653,7 @@ export class TampDecompressor {
     }
 
     this.headerRead = true;
-    return 1; // Header consumed 1 byte
+    return headerBytesConsumed;
   }
 
   /**
@@ -792,13 +841,24 @@ export async function compress(data, options = {}) {
   const callbackOptions = {};
 
   // Extract compression-specific options
-  const { window, literal, dictionary, extended, lazy_matching, onPoll, signal, pollIntervalMs, pollIntervalBytes } =
-    options;
+  const {
+    window,
+    literal,
+    dictionary,
+    extended,
+    lazy_matching,
+    dictionary_reset,
+    onPoll,
+    signal,
+    pollIntervalMs,
+    pollIntervalBytes,
+  } = options;
   if (window !== undefined) compressionOptions.window = window;
   if (literal !== undefined) compressionOptions.literal = literal;
   if (dictionary !== undefined) compressionOptions.dictionary = dictionary;
   if (extended !== undefined) compressionOptions.extended = extended;
   if (lazy_matching !== undefined) compressionOptions.lazy_matching = lazy_matching;
+  if (dictionary_reset !== undefined) compressionOptions.dictionary_reset = dictionary_reset;
 
   // Extract callback options
   callbackOptions.onPoll = onPoll;

--- a/wasm/src/tamp.js
+++ b/wasm/src/tamp.js
@@ -5,7 +5,8 @@
 
 import TampModule from './tamp-module.mjs';
 
-// Error codes from C library
+// Status codes from C library
+const TAMP_OK = 0;
 const TAMP_ERROR = -1;
 const TAMP_EXCESS_BITS = -2;
 const TAMP_INVALID_CONF = -3;
@@ -321,7 +322,7 @@ export class TampCompressor {
               [this.compressorPtr, outputPtr + chunkOutputWritten, CHUNK_SIZE - chunkOutputWritten, pollOutputSizePtr]
             );
 
-            if (pollResult !== 0) {
+            if (pollResult !== TAMP_OK) {
               throwOnError(pollResult, 'Compression poll');
             }
 
@@ -587,6 +588,11 @@ export class TampDecompressor {
     );
 
     throwOnError(headerResult, 'Header reading');
+    if (headerResult !== TAMP_OK) {
+      // TAMP_INPUT_EXHAUSTED: not enough bytes for header yet.
+      // Return 0 so caller retries with more data.
+      return 0;
+    }
 
     const headerBytesConsumed = this.module.getValue(this.inputConsumedPtr, 'i32');
 
@@ -850,6 +856,7 @@ export async function compress(data, options = {}) {
     extended,
     lazy_matching,
     dictionary_reset,
+    append,
     onPoll,
     signal,
     pollIntervalMs,
@@ -861,6 +868,7 @@ export async function compress(data, options = {}) {
   if (extended !== undefined) compressionOptions.extended = extended;
   if (lazy_matching !== undefined) compressionOptions.lazy_matching = lazy_matching;
   if (dictionary_reset !== undefined) compressionOptions.dictionary_reset = dictionary_reset;
+  if (append !== undefined) compressionOptions.append = append;
 
   // Extract callback options
   callbackOptions.onPoll = onPoll;
@@ -871,7 +879,9 @@ export async function compress(data, options = {}) {
   const compressor = new TampCompressor(compressionOptions);
   try {
     const compressed = await compressor.compress(data, callbackOptions);
-    const flushed = await compressor.flush();
+    // When dictionary_reset is enabled, emit a trailing FLUSH token so a
+    // future append-mode compressor can form a double-FLUSH.
+    const flushed = await compressor.flush(compressionOptions.dictionary_reset);
 
     // Concatenate compressed data and flush output
     const result = new Uint8Array(compressed.length + flushed.length);

--- a/wasm/src/tamp.js
+++ b/wasm/src/tamp.js
@@ -125,6 +125,7 @@ export class TampCompressor {
       extended: true,
       lazy_matching: false,
       dictionary_reset: false,
+      append: false,
       ...options,
     };
 
@@ -192,7 +193,8 @@ export class TampCompressor {
         ((this.options.dictionary ? 1 : 0) << 8) |
         ((this.options.extended ? 1 : 0) << 9) |
         ((this.options.dictionary_reset ? 1 : 0) << 10) |
-        ((this.options.lazy_matching ? 1 : 0) << 11);
+        ((this.options.append ? 1 : 0) << 11) |
+        ((this.options.lazy_matching ? 1 : 0) << 12);
       this.module.setValue(confPtr, confValue, 'i32');
 
       // Initialize compressor

--- a/wasm/src/tamp.js
+++ b/wasm/src/tamp.js
@@ -322,12 +322,13 @@ export class TampCompressor {
               [this.compressorPtr, outputPtr + chunkOutputWritten, CHUNK_SIZE - chunkOutputWritten, pollOutputSizePtr]
             );
 
-            if (pollResult !== TAMP_OK) {
-              throwOnError(pollResult, 'Compression poll');
-            }
-
             const pollOutputSize = this.module.getValue(pollOutputSizePtr, 'i32');
             chunkOutputWritten += pollOutputSize;
+
+            if (pollResult !== TAMP_OK) {
+              throwOnError(pollResult, 'Compression poll');
+              break; // TAMP_OUTPUT_FULL: flush this chunk, continue in outer loop
+            }
 
             // Call progress callback if provided (after successful compression)
             // Use throttling to reduce callback overhead


### PR DESCRIPTION
## Summary
  - Add dictionary reset via double-FLUSH token sequence, enabling append-to-stream without retaining prior compressor state. Both sides re-initialize the window and continue with a fresh dictionary.
  - Uses the previously reserved `more_header` header bit to signal dictionary-reset-capable streams. Old decompressors (<2.1.0) reject these streams at the header, preventing silent corruption.
  - Add `conf.append` mode: writes a FLUSH instead of a header, allowing a new compressor to resume an existing stream after reboot.
  - Implemented across all bindings: C, Python, Cython, MicroPython, and JavaScript/WASM.

  ## Protocol
  - `more_header` (header byte 1, bit 0) now implies `dictionary_reset`
  - Header byte 2 added (all bits reserved, must be zero)
  - Two consecutive FLUSH tokens signal dictionary re-initialization
  - FLUSH is always emitted (even when byte-aligned) in `more_header` streams to support append detection

  ## API
  - `TampConf.dictionary_reset` / `TampConf.append` config fields
  - `tamp_compressor_reset_dictionary()` (C) / `Compressor.reset_dictionary()` (Python/JS)
  - Decompressor automatically handles double-FLUSH when `more_header` is set
