### PR TITLE
Fix off-by-one in ESP32-S3 SIMD match finder

### DIFF
--- a/espidf/tamp/private/tamp_search.hpp
+++ b/espidf/tamp/private/tamp_search.hpp
@@ -893,7 +893,7 @@ class Locator {
             // Pointer to potential match on last byte of pattern:
             const uint8_t* last = first + patLen - 1;
 
-            const uint8_t* const end = first + dataLen - patLen;
+            const uint8_t* const end = first + dataLen - patLen + 1;
 
             // Using (q1:q0) to load+align 'first' data,
             // (q3:q2) to load+align 'last' data


### PR DESCRIPTION
The SIMD path of find_pattern() computed the search bound as `first + dataLen - patLen`, causing the `s1 <= end` candidate check to reject a valid match starting at `dataLen - patLen` (ending exactly on the last byte of the window). Add +1 to match the inclusive last valid start position, aligning with the scalar implementation.

Impact was suboptimal compression only (output occasionally 1 byte larger than optimal); never corrupt data. S3-only.

Fixes #316