### PR TITLE
Suppress accidental double-FLUSH to prevent dictionary-reset desync

### DIFF
--- a/ctests/test_compressor.c
+++ b/ctests/test_compressor.c
@@ -544,6 +544,74 @@ void test_reset_dictionary_small_output_buffer(void) {
     TEST_ASSERT_EQUAL_MEMORY(data2, output + strlen(data1), strlen(data2));
 }
 
+void test_double_flush_does_not_reset(void) {
+    // A redundant flush(write_token=true) must NOT emit a second consecutive FLUSH.
+    // With dictionary_reset=true, two FLUSH tokens with no data between them are the
+    // double-FLUSH reset signal: the decompressor would re-initialize its window while
+    // this compressor's window stays put, corrupting all later output. The redundant
+    // FLUSH must be suppressed so the stream round-trips cleanly.
+    tamp_res res;
+    TampCompressor compressor;
+    unsigned char c_window[1 << 10];
+    unsigned char compressed[512];
+    size_t total_written = 0;
+    size_t chunk_written, input_consumed;
+    TampConf conf = {
+        .window = 10,
+        .literal = 8,
+        .extended = true,
+        .dictionary_reset = true,
+    };
+
+    res = tamp_compressor_init(&compressor, &conf, c_window);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+
+    const char *data1 = "Hello world! Hello world! Hello world! ";
+    res = tamp_compressor_compress(&compressor, compressed, sizeof(compressed), &chunk_written,
+                                   (const unsigned char *)data1, strlen(data1), &input_consumed);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // First flush emits a FLUSH; the next two redundant flushes must emit nothing.
+    res = tamp_compressor_flush(&compressor, compressed + total_written, sizeof(compressed) - total_written,
+                                &chunk_written, true);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    for (int i = 0; i < 2; i++) {
+        res = tamp_compressor_flush(&compressor, compressed + total_written, sizeof(compressed) - total_written,
+                                    &chunk_written, true);
+        TEST_ASSERT_EQUAL(TAMP_OK, res);
+        TEST_ASSERT_EQUAL(0, chunk_written);  // redundant FLUSH suppressed
+        total_written += chunk_written;
+    }
+
+    const char *data2 = "Goodbye world! Goodbye world! Goodbye world! ";
+    res = tamp_compressor_compress_and_flush(&compressor, compressed + total_written,
+                                             sizeof(compressed) - total_written, &chunk_written,
+                                             (const unsigned char *)data2, strlen(data2), &input_consumed, false);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+    total_written += chunk_written;
+
+    // Decompress: must recover data1 + data2 with no dictionary reset in between.
+    TampDecompressor decompressor;
+    unsigned char d_window[1 << 10];
+    unsigned char output[512];
+    size_t output_written;
+
+    res = tamp_decompressor_init(&decompressor, NULL, d_window, 10);
+    TEST_ASSERT_EQUAL(TAMP_OK, res);
+
+    res = tamp_decompressor_decompress(&decompressor, output, sizeof(output), &output_written, compressed,
+                                       total_written, NULL);
+    TEST_ASSERT_GREATER_OR_EQUAL(TAMP_OK, res);
+
+    size_t expected_size = strlen(data1) + strlen(data2);
+    TEST_ASSERT_EQUAL(expected_size, output_written);
+    TEST_ASSERT_EQUAL_MEMORY(data1, output, strlen(data1));
+    TEST_ASSERT_EQUAL_MEMORY(data2, output + strlen(data1), strlen(data2));
+}
+
 void test_compress_cb_callback_abort(void) {
     TampCompressor compressor;
     unsigned char window[1 << 10];

--- a/ctests/test_runner.c
+++ b/ctests/test_runner.c
@@ -38,6 +38,7 @@ int main(void) {
     RUN_TEST(test_reset_dictionary_roundtrip);
     RUN_TEST(test_reset_dictionary_requires_conf_flag);
     RUN_TEST(test_reset_dictionary_small_output_buffer);
+    RUN_TEST(test_double_flush_does_not_reset);
 
     // Decompressor extended tests
     RUN_TEST(test_decompressor_extended_rle);

--- a/tamp/_c_src/tamp/compressor.c
+++ b/tamp/_c_src/tamp/compressor.c
@@ -208,6 +208,9 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_init(TampCompressor* compressor, con
         // previous stream's trailing FLUSH, this triggers a dictionary reset.
         write_to_bit_buffer(compressor, FLUSH_CODE, 9);
         compressor->bit_buffer_pos = 16;
+        // This FLUSH is the most recently emitted token; mark it so an immediate
+        // redundant flush() doesn't append a second FLUSH and over-signal a reset.
+        compressor->last_was_flush = 1;
     } else {
         // Header byte 1: [window:3][literal:2][use_custom_dictionary:1][extended:1][more_headers:1]
         uint8_t header = ((conf->window - 8) << 5) | ((conf->literal - 5) << 3) | (conf->use_custom_dictionary << 2) |
@@ -491,6 +494,10 @@ TAMP_NOINLINE tamp_res tamp_compressor_poll(TampCompressor* compressor, unsigned
 
     if (TAMP_UNLIKELY(compressor->input_size == 0)) return TAMP_OK;
 
+    // Real data is being processed: any pending RLE/extended state drained by a
+    // later flush() was also created here, so the next FLUSH won't be "consecutive".
+    compressor->last_was_flush = 0;
+
     // Make sure there's enough room in the bit buffer.
     res = partial_flush(compressor, &output, &output_size, output_written_size);
     if (TAMP_UNLIKELY(res != TAMP_OK)) return res;
@@ -711,7 +718,14 @@ flush_check:
 flush_done:
     // At this point, up to 7 bits may remain in the compressor->bit_buffer
     // The output buffer may have 0 bytes remaining.
-    if (write_token && (compressor->bit_buffer_pos || compressor->conf.dictionary_reset)) {
+    // Suppress a redundant second consecutive FLUSH. Two FLUSH tokens with no data
+    // between them are the double-FLUSH dictionary-reset signal: a decompressor on a
+    // dictionary_reset stream would re-initialize its window, but THIS compressor's
+    // window is not reset here, desyncing the two and corrupting all later output.
+    // The sanctioned reset path, tamp_compressor_reset_dictionary(), clears
+    // last_was_flush before each flush so it can still emit the real double-FLUSH.
+    if (write_token && !compressor->last_was_flush &&
+        (compressor->bit_buffer_pos || compressor->conf.dictionary_reset)) {
         // We don't want to write the FLUSH token to the bit_buffer unless
         // we are confident that it'll wind up in the output buffer
         // in THIS function call.
@@ -719,6 +733,7 @@ flush_done:
         // end up accidentally writing multiple FLUSH tokens.
         if (TAMP_UNLIKELY(output_size < 2)) return TAMP_OUTPUT_FULL;
         write_to_bit_buffer(compressor, FLUSH_CODE, 9);
+        compressor->last_was_flush = 1;
     }
 
     // At this point, up to 16 bits may remain in the compressor->bit_buffer
@@ -787,6 +802,9 @@ TAMP_OPTIMIZE_SIZE tamp_res tamp_compressor_reset_dictionary(TampCompressor* com
     // FLUSH token even when bit_buffer_pos is 0.
     for (uint8_t i = 0; i < 2; i++) {
         size_t flush_written_size;
+        // Bypass the double-FLUSH suppression in flush(): here we *intend* to emit
+        // two consecutive FLUSH tokens, paired with the dictionary re-init below.
+        compressor->last_was_flush = 0;
         res = tamp_compressor_flush(compressor, output, output_size, &flush_written_size, true);
         *output_written_size += flush_written_size;
         if (TAMP_UNLIKELY(res != TAMP_OK)) return res;

--- a/tamp/_c_src/tamp/compressor.h
+++ b/tamp/_c_src/tamp/compressor.h
@@ -23,6 +23,8 @@ typedef struct TampCompressor {
 
     /* WARM: read frequently, often cached in locals */
     uint8_t min_pattern_size;  // Minimum pattern size (2 bits used; 2 or 3)
+    uint8_t last_was_flush;    // 1 if the most recently emitted token was a FLUSH (no data since).
+                               // Suppresses an accidental double-FLUSH (a dictionary-reset signal).
     TampConf conf;
 #else   // Use bitfields for reduced memory-usage
     /* HOT: accessed every iteration of the compression loop */
@@ -52,6 +54,14 @@ typedef struct TampCompressor {
 #if TAMP_EXTENDED_COMPRESS
     uint8_t rle_count;             // Current RLE run length (max 241)
     uint8_t extended_match_count;  // Current extended match size (max ~134)
+#endif
+#if !TAMP_ESP32
+    // 1 if the most recently emitted token was a FLUSH (no data since); suppresses an
+    // accidental double-FLUSH (a dictionary-reset signal). Placed at the struct tail (in
+    // existing padding) so it does NOT shift the trailing fields above to higher offsets,
+    // which would push them out of Cortex-M0+ small load/store immediate range and bloat
+    // unrelated functions. The ESP32 variant keeps it inline (free in WARM-section padding).
+    uint8_t last_was_flush;
 #endif
 } TampCompressor;
 

--- a/tamp/compressor.py
+++ b/tamp/compressor.py
@@ -237,6 +237,9 @@ class Compressor:
             # trailing FLUSH, this triggers a dictionary reset in the decompressor.
             self._bit_writer.write(_FLUSH_CODE, 9, flush=False)
             self._bit_writer.bit_pos = 16  # Pad to 2 bytes (bits are already zero)
+            # This FLUSH is the most recently emitted token; mark it so an immediate
+            # redundant flush() doesn't append a second FLUSH and over-signal a reset.
+            self._last_was_flush = True
         else:
             # Write header
             self._bit_writer.write(window - 8, 3, flush=False)
@@ -265,6 +268,9 @@ class Compressor:
         self._extended_match_position = 0
         self._cached_match_index = -1
         self._cached_match_size = 0
+        # True if the most recently emitted token was a FLUSH with no data since.
+        # Suppresses an accidental double-FLUSH (a dictionary-reset signal).
+        self._last_was_flush = False
 
     def _validate_no_match_overlap(self, write_pos, match_index, match_size):
         """Check if writing a single byte will overlap with a future match section."""
@@ -275,6 +281,10 @@ class Compressor:
 
         if not self._input_buffer:
             return bytes_written
+
+        # Real data is being processed: any pending RLE/extended state drained by a
+        # later flush() was also created here, so the next FLUSH won't be "consecutive".
+        self._last_was_flush = False
 
         if self._extended_match_count:
             while self._input_buffer:
@@ -567,8 +577,15 @@ class Compressor:
             self._cached_match_index = -1
             self._cached_match_size = 0
 
-        bytes_written_flush = self._bit_writer.flush(write_token=write_token, force_token=self.dictionary_reset)
-        bytes_written += bytes_written_flush
+        # Suppress a redundant second consecutive FLUSH. Two FLUSH tokens with no
+        # data between them are the double-FLUSH dictionary-reset signal: a
+        # decompressor on a dictionary_reset stream would re-initialize its window,
+        # but this compressor's window is not reset here, desyncing the two. The
+        # sanctioned reset path, reset_dictionary(), emits its FLUSH tokens directly.
+        emit_token = write_token and not self._last_was_flush
+        bytes_written += self._bit_writer.flush(write_token=emit_token, force_token=self.dictionary_reset)
+        if self._bit_writer._flush_token_written:
+            self._last_was_flush = True
         return bytes_written
 
     def reset_dictionary(self) -> int:
@@ -593,21 +610,15 @@ class Compressor:
 
         bytes_written = 0
 
-        # Flush all pending data with write_token=True.
-        bytes_written += self.flush(write_token=True)
-
-        # We need exactly 2 consecutive FLUSHes in the stream.
-        # If flush already wrote one, we need 1 more; otherwise 2.
-        flushes_needed = 1 if self._bit_writer._flush_token_written else 2
-        for _ in range(flushes_needed):
-            bytes_written += self._bit_writer.write(_FLUSH_CODE, 9)
-            # Pad to byte boundary
-            if self._bit_writer.bit_pos > 0:
-                byte = (self._bit_writer.buffer >> 24) & 0xFF
-                self._bit_writer.f.write(byte.to_bytes(1, "big"))
-                self._bit_writer.bit_pos = 0
-                self._bit_writer.buffer = 0
-                bytes_written += 1
+        # Write 2 FLUSH tokens for the double-FLUSH reset signal. The first drains
+        # any pending data. dictionary_reset being set guarantees flush() writes a
+        # FLUSH token even when the bit buffer is empty. Clearing _last_was_flush
+        # before each flush bypasses the double-FLUSH suppression in flush(): here
+        # we *intend* to emit two consecutive FLUSH tokens, paired with the
+        # dictionary re-init below. Mirrors tamp_compressor_reset_dictionary in C.
+        for _ in range(2):
+            self._last_was_flush = False
+            bytes_written += self.flush(write_token=True)
 
         # Re-initialize dictionary with default and reset all mutable state,
         # matching what the decompressor does on a double-FLUSH reset

--- a/tests/test_compressor_decompressor.py
+++ b/tests/test_compressor_decompressor.py
@@ -529,6 +529,31 @@ class TestCompressorAndDecompressor(unittest.TestCase):
                 actual = d.read()
                 self.assertEqual(actual, data1 + data2)
 
+    def test_double_flush_does_not_reset(self):
+        """An accidental redundant flush() must not emit a corrupting double-FLUSH.
+
+        With dictionary_reset=True every flush(write_token=True) would otherwise
+        emit a FLUSH token. Two in a row (no data between) form the double-FLUSH
+        dictionary-reset signal, which would reset the decompressor's window while
+        the compressor's window stays put -> corruption. The redundant FLUSH must
+        be suppressed so the stream round-trips cleanly.
+        """
+        data1 = b"Hello world! " * 20
+        data2 = b"Goodbye world! " * 20
+        for Compressor, Decompressor in walk_compressors_decompressors():
+            with BytesIO() as f, self.subTest(Compressor=Compressor, Decompressor=Decompressor):
+                c = Compressor(f, dictionary_reset=True)
+                c.write(data1)
+                c.flush(write_token=True)
+                c.flush(write_token=True)  # redundant: must NOT signal a reset
+                c.flush(write_token=True)  # still must NOT signal a reset
+                c.write(data2)
+                c.flush(write_token=False)
+
+                f.seek(0)
+                d = Decompressor(f)
+                self.assertEqual(d.read(), data1 + data2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The decompressor re-initializes its window when it sees a double-flush. With `dictionary_reset=true`, every `flush(write_token=true)` emits a `FLUSH`, so calling `flush` twice with no intervening data emitted two consecutive `FLUSH` tokens. The decompressor would reset its window while the compressor's window stayed put, desyncing the two and corrupting all subsequent output.

Track `last_was_flush` on the compressor so a redundant second consecutive `FLUSH` is suppressed (collapsing to a harmless single `FLUSH`). The flag is cleared whenever real data is processed and set when a `FLUSH` is emitted. The sanctioned reset path (`tamp_compressor_reset_dictionary`) clears the flag before each flush so it still emits its deliberate double-`FLUSH`, paired with a real window re-init. Append mode sets the flag since its leading `FLUSH` is the most-recently-emitted token.

The hot-path clear in `tamp_compressor_poll` compiles to a single free `strb` (reuses an already-materialized zero register). On non-ESP32 the flag is placed at the struct tail (in existing padding) rather than next to `min_pattern_size`: an inline byte there shifts every trailing field +2, pushing them out of Cortex-M0+ small load/store immediate range and bloating unrelated functions. Tail placement keeps `sizeof(TampCompressor)` unchanged and saves 38 bytes on armv6m in the default extended config (2924 -> 2886). ESP32 keeps the inline placement (already free).

Mirrored in the pure-Python reference. WASM and the MicroPython native module inherit the fix via the shared C source. The Viper compressor has no dictionary_reset support and was already safe.

Adds regression tests in both pytest and the C unit suite.