### PR TITLE
Use PyPI trusted publishing in upload_to_pypi job

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -427,6 +427,11 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     needs: ['validate_wheels']
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tamp
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -436,6 +441,5 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: wheels/
           skip-existing: true


### PR DESCRIPTION
Switch the publish step to OIDC trusted publishing via the `pypi` environment and `id-token: write` permission instead of a long-lived PYPI_TOKEN secret. The cibuildwheel build matrix is unchanged.