### PR TITLE
Replace LFS ground-truth binaries with recorded compression hashes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-datasets/v1-compressed/** filter=lfs diff=lfs merge=lfs -text
-datasets/extended-compressed/** filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -94,48 +94,100 @@ jobs:
           source .venv/bin/activate
           SKIP=wasm-eslint,wasm-npm-test,wasm-file-validation,typescript-check,package-json-lint pre-commit run --show-diff-on-failure --color=always --all-files
 
-  cache-lfs:
-    name: 'Cache LFS files'
+  fetch-corpora:
+    # Download the external benchmark corpora (enwik8, silesia, micropython uf2) exactly
+    # once per cache lifetime and cache them, so the corpus-consuming jobs below restore
+    # instead of re-hitting the upstream hosts (mattmahoney.net, micropython.org).
+    name: 'Fetch corpora'
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-    outputs:
-      cache-key: ${{ steps.lfs-key.outputs.key }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Cache corpora
+        uses: actions/cache@v4
+        id: cached-corpora
+        with:
+          path: datasets
+          key: corpora-enwik8-silesia-uf2-v1
+
+      - name: Download corpora
+        if: steps.cached-corpora.outputs.cache-hit != 'true'
+        run: make download-enwik8 download-silesia download-micropython
+
+  dataset-regression:
+    # Compresses the enwik8/silesia/uf2 corpora with the current implementation and
+    # asserts the output hashes to the recorded ground-truth values (see
+    # tests/test_dataset_regression.py). Replaces the old git-LFS ground-truth binaries.
+    name: 'Dataset regression'
+    needs: fetch-corpora
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    env:
+      POETRY_HOME: '~/poetry'
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: false
 
-      - name: Compute LFS cache key
-        id: lfs-key
-        run: |
-          # Hash pointer files before they get replaced by git lfs pull
-          # Use find for reliable recursive globbing, sort for deterministic order
-          hash=$(find datasets/v1-compressed datasets/extended-compressed -name '*.tamp' -type f | sort | xargs cat | sha256sum | cut -d' ' -f1)
-          echo "key=lfs-${hash}" >> $GITHUB_OUTPUT
-          echo "Cache key: lfs-${hash}"
-
-      - name: Restore LFS cache
+      - name: Restore corpora
         uses: actions/cache/restore@v4
-        id: lfs-cache
+        id: cached-corpora
         with:
-          path: .git/lfs
-          key: ${{ steps.lfs-key.outputs.key }}
+          path: datasets
+          key: corpora-enwik8-silesia-uf2-v1
 
-      - name: Pull LFS files
-        if: steps.lfs-cache.outputs.cache-hit != 'true'
-        run: git lfs pull
+      - name: Download corpora (fallback if cache evicted)
+        if: steps.cached-corpora.outputs.cache-hit != 'true'
+        run: make download-enwik8 download-silesia download-micropython
 
-      - name: Save LFS cache
-        if: steps.lfs-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+      - name: Set up python 3.13
+        id: setup-python
+        uses: actions/setup-python@v5
         with:
-          path: .git/lfs
-          key: ${{ steps.lfs-key.outputs.key }}
+          python-version: '3.13'
+
+      - name: Cache Poetry Install
+        uses: actions/cache@v4
+        id: cached-poetry
+        with:
+          path: ${{ env.POETRY_HOME }}
+          key: poetry-cache-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.github/workflows/tests.yaml') }}
+
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        with:
+          version: 1.8.5
+
+      - name: Add Poetry to PATH
+        run: echo "$POETRY_HOME/bin" >> $GITHUB_PATH
+
+      - name: Configure Poetry
+        run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        id: cached-venv
+        with:
+          path: .venv/
+          key: venv-dataset-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install library
+        run: poetry install --extras cli --no-interaction
+
+      - name: Run dataset regression tests
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/test_dataset_regression.py -v
 
   test:
     name: 'Test Python ${{ matrix.python-version }}'
-    needs: cache-lfs
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
@@ -150,17 +202,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: false
-
-      - name: Restore LFS cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .git/lfs
-          key: ${{ needs.cache-lfs.outputs.cache-key }}
-          fail-on-cache-miss: true
-
-      - name: Pull LFS files
-        run: git lfs pull
 
       - name: Set up python 3.13 (for Poetry)
         id: setup-python-system
@@ -217,7 +258,8 @@ jobs:
       - name: Run CPython tests with sanitizers
         run: |
           source .venv/bin/activate
-          LD_PRELOAD=$(gcc -print-file-name=libasan.so) python -m pytest --cov=tamp --cov-report term --cov-report xml --junitxml=testresults.xml
+          # Dataset regression (large-corpus compression) runs in its own job; skip it here.
+          LD_PRELOAD=$(gcc -print-file-name=libasan.so) python -m pytest --no-dataset --cov=tamp --cov-report term --cov-report xml --junitxml=testresults.xml
           coverage report
 
       - name: Run MicroPython tests (reference implementation)
@@ -259,6 +301,7 @@ jobs:
 
   integrity-enwik8:
     name: 'CLI Integrity (enwik8) - ${{ matrix.implementation }}'
+    needs: fetch-corpora
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
@@ -322,13 +365,15 @@ jobs:
           echo "ASAN_OPTIONS=detect_leaks=0" >> $GITHUB_ENV
           echo "UBSAN_OPTIONS=print_stacktrace=1" >> $GITHUB_ENV
 
-      - name: Cache enwik8 dataset
-        uses: actions/cache@v4
+      - name: Restore corpora
+        uses: actions/cache/restore@v4
+        id: cached-corpora
         with:
-          path: datasets/enwik8.zip
-          key: enwik8-dataset-v2
+          path: datasets
+          key: corpora-enwik8-silesia-uf2-v1
 
-      - name: Download enwik8 dataset
+      - name: Download enwik8 dataset (fallback if cache evicted)
+        if: steps.cached-corpora.outputs.cache-hit != 'true'
         run: make download-enwik8
 
       - name: Verify CLI compression/decompression integrity

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -176,7 +176,7 @@ jobs:
         id: cached-venv
         with:
           path: .venv/
-          key: venv-dataset-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+          key: venv-dataset-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'build.py', 'tamp/_c_src/**', 'tamp/*.pyx') }}
 
       - name: Install library
         run: poetry install --extras cli --no-interaction
@@ -241,7 +241,7 @@ jobs:
         id: cached-venv
         with:
           path: .venv/
-          key: venv-test-${{ runner.os }}-${{ steps.setup-python-project.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+          key: venv-test-${{ runner.os }}-${{ steps.setup-python-project.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'build.py', 'tamp/_c_src/**', 'tamp/*.pyx') }}
 
       - name: Install MicroPython
         uses: BrianPugh/install-micropython@v2

--- a/.gitignore
+++ b/.gitignore
@@ -246,15 +246,11 @@ Temporary Items
 *.tmp
 *.trace
 
-# Compression benchmark datasets
+# Compression benchmark datasets (downloaded/regenerated locally, never committed)
 datasets/*
-!datasets/v1-compressed/
-!datasets/extended-compressed/
 enwik8*
 *.pkl
 *.tamp
-!datasets/v1-compressed/**
-!datasets/extended-compressed/**
 
 # Cython-generated files
 tamp/_c_build_dictionary.c

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ help:
 	@echo ""
 	@echo "Other targets:"
 	@echo "  make binary-size        Show binary sizes for README table"
-	@echo "  make v1-compressed-datasets  Compress all datasets/ files to datasets/v1-compressed/"
+	@echo "  make v1-compressed-datasets        Regenerate ground-truth v1 (--no-extended) .tamp binaries"
+	@echo "  make extended-compressed-datasets  Regenerate ground-truth extended .tamp binaries"
 	@echo "  make c-benchmark-stream Benchmark stream API with various temporary working buffer sizes"
 	@echo "  make download-enwik8    Download enwik8 test dataset"
 	@echo "  make download-sms       Download UCI SMS Spam Collection"
@@ -146,7 +147,7 @@ endif
 # Data Downloads
 ################
 # Datasets are stored in datasets/ to persist across `make clean`
-.PHONY: download-enwik8 download-silesia download-sms download-tweets v1-compressed-datasets
+.PHONY: download-enwik8 download-silesia download-sms download-tweets v1-compressed-datasets extended-compressed-datasets
 
 datasets/enwik8.zip:
 	@mkdir -p datasets
@@ -197,20 +198,33 @@ download-tweets: datasets/tweets.txt
 
 .PHONY: download-tweets
 
+# Regenerate the ground-truth compressed binaries. These are no longer committed
+# (tests/test_dataset_regression.py stores only their SHA256s and re-derives them);
+# use these targets when you actually need the binaries on disk. The recorded
+# hashes identify the exact files these targets must produce.
 v1-compressed-datasets: datasets/enwik8 datasets/silesia
 	@mkdir -p datasets/v1-compressed
 	@for f in datasets/*; do \
 		[ -f "$$f" ] || continue; \
 		base=$$(basename "$$f"); \
 		echo "Compressing $$f -> datasets/v1-compressed/$$base.tamp"; \
-		poetry run tamp compress "$$f" -o "datasets/v1-compressed/$$base.tamp"; \
+		poetry run tamp compress --no-extended "$$f" -o "datasets/v1-compressed/$$base.tamp"; \
 	done
 	@mkdir -p datasets/v1-compressed/silesia
 	@for f in datasets/silesia/*; do \
 		[ -f "$$f" ] || continue; \
 		base=$$(basename "$$f"); \
 		echo "Compressing $$f -> datasets/v1-compressed/silesia/$$base.tamp"; \
-		poetry run tamp compress "$$f" -o "datasets/v1-compressed/silesia/$$base.tamp"; \
+		poetry run tamp compress --no-extended "$$f" -o "datasets/v1-compressed/silesia/$$base.tamp"; \
+	done
+
+extended-compressed-datasets: datasets/enwik8 datasets/silesia
+	@mkdir -p datasets/extended-compressed
+	@for f in datasets/* datasets/silesia/*; do \
+		[ -f "$$f" ] || continue; \
+		base=$$(basename "$$f"); \
+		echo "Compressing $$f -> datasets/extended-compressed/$$base.tamp"; \
+		poetry run tamp compress --extended "$$f" -o "datasets/extended-compressed/$$base.tamp"; \
 	done
 
 # Derived test files (OK to be in build/, quick to regenerate)

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ endif
 # Data Downloads
 ################
 # Datasets are stored in datasets/ to persist across `make clean`
-.PHONY: download-enwik8 download-silesia download-sms download-tweets v1-compressed-datasets extended-compressed-datasets
+.PHONY: download-enwik8 download-silesia download-sms download-tweets download-micropython v1-compressed-datasets extended-compressed-datasets
 
 datasets/enwik8.zip:
 	@mkdir -p datasets

--- a/datasets/extended-compressed/RPI_PICO-20250415-v1.25.0.uf2.tamp
+++ b/datasets/extended-compressed/RPI_PICO-20250415-v1.25.0.uf2.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94be865699e667ceffb7bae10bc5c040fe6cdc22b9e02e61bd88363d767ec171
-size 289454

--- a/datasets/extended-compressed/dickens.tamp
+++ b/datasets/extended-compressed/dickens.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01482dc4fa9c7c7674eca711a378d8d1ac7c59615b326a8d9a06f09bc9f33c30
-size 5538353

--- a/datasets/extended-compressed/enwik8.tamp
+++ b/datasets/extended-compressed/enwik8.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9d804c91b4dc5e81856db074760037040421cfa84e1ea211e16dde8c295ce6d
-size 51016917

--- a/datasets/extended-compressed/mozilla.tamp
+++ b/datasets/extended-compressed/mozilla.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53497c04175742c323b7e086a4f0ce44533c8f238ef85562591c79a587a81679
-size 24413362

--- a/datasets/extended-compressed/mr.tamp
+++ b/datasets/extended-compressed/mr.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94f27dfffe842fff3669e80eb5a3c769c33cd591f08001ae5e2eb95ff152a1fc
-size 4520091

--- a/datasets/extended-compressed/nci.tamp
+++ b/datasets/extended-compressed/nci.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0acbb7c787947df92ab4a44d4259f52d327d98dd2ec5860a998c51ed32409753
-size 6824403

--- a/datasets/extended-compressed/ooffice.tamp
+++ b/datasets/extended-compressed/ooffice.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae3bcd7bbff8f223a2c4ca937a5e2eafd793c8abda48d203ed110e98f2896526
-size 3773003

--- a/datasets/extended-compressed/osdb.tamp
+++ b/datasets/extended-compressed/osdb.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1eb802368db32844da9c195095cb6727f0c39f719325ac23c446cee2de1d557d
-size 8466875

--- a/datasets/extended-compressed/reymont.tamp
+++ b/datasets/extended-compressed/reymont.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4024c6820a3af628dd2059c9261b2713c9a8f48b4a26e57c45a9776fec9b8068
-size 2818554

--- a/datasets/extended-compressed/samba.tamp
+++ b/datasets/extended-compressed/samba.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f13c7e856a8e0366b7c2fa58de56bde427bf1840335e596a70db46a6aff4feec
-size 8383534

--- a/datasets/extended-compressed/sao.tamp
+++ b/datasets/extended-compressed/sao.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c05ac1c7d78b04874f07e10265cd254ecf9d6dcf1a3f0d1ea695815509ff0b1
-size 6136077

--- a/datasets/extended-compressed/webster.tamp
+++ b/datasets/extended-compressed/webster.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91d3c9ddb94e370d4f9cb518e846fda8a197bd9ef4ea4fcb91f84688af49316a
-size 18146641

--- a/datasets/extended-compressed/x-ray.tamp
+++ b/datasets/extended-compressed/x-ray.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ba0c1fb79addae24888c12a466e84b73c32ca608836c458487226d224a63fc3
-size 7509449

--- a/datasets/extended-compressed/xml.tamp
+++ b/datasets/extended-compressed/xml.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11a9d7e077f31a83b06cbcfb95c6ef2d74355e6f6af9decba3c2e3529e1e903f
-size 1472562

--- a/datasets/v1-compressed/RPI_PICO-20250415-v1.25.0.uf2.tamp
+++ b/datasets/v1-compressed/RPI_PICO-20250415-v1.25.0.uf2.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b14029d9171b6fdff493b03db6634cf20d654674fbd68c0ea6e1b321af1a4aad
-size 331310

--- a/datasets/v1-compressed/enwik8.tamp
+++ b/datasets/v1-compressed/enwik8.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02e05af059a0040d641988075cf1dfc479a084f9a34b5c8a348354211c5fa038
-size 51635633

--- a/datasets/v1-compressed/silesia/dickens.tamp
+++ b/datasets/v1-compressed/silesia/dickens.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:caacd14fc2a6bbf5b8ee13b49f94d1ddab2b8eba8e6379685ee67f6b309f33fd
-size 5546761

--- a/datasets/v1-compressed/silesia/mozilla.tamp
+++ b/datasets/v1-compressed/silesia/mozilla.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a4d69d28071e4327917be293ff4c9cd9c1b362a48d8f15d5693b786622e7343
-size 25121385

--- a/datasets/v1-compressed/silesia/mr.tamp
+++ b/datasets/v1-compressed/silesia/mr.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7862014d14955b765959ddc875f00f36401b49654e75a564f9313b9ac04c35dd
-size 5027032

--- a/datasets/v1-compressed/silesia/nci.tamp
+++ b/datasets/v1-compressed/silesia/nci.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb20a8e688046e36d123d2528c16c12dfa75e6cb1ae6e7bbf7d634f80ea7ae07
-size 8643610

--- a/datasets/v1-compressed/silesia/ooffice.tamp
+++ b/datasets/v1-compressed/silesia/ooffice.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d7c35aae8fc664d89350fbf6162db34151f7ef85175c555d4c366f23ecd2b80
-size 3814938

--- a/datasets/v1-compressed/silesia/osdb.tamp
+++ b/datasets/v1-compressed/silesia/osdb.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e28f5f7cb1173a288cdaadfedb3a554ed50af3bb297fe029964876d7345d69b
-size 8520835

--- a/datasets/v1-compressed/silesia/reymont.tamp
+++ b/datasets/v1-compressed/silesia/reymont.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f81ae5f8ae000a3ba898efea3c4b303628fe2d3d432f8913f07d5feac9274e3f
-size 2847981

--- a/datasets/v1-compressed/silesia/samba.tamp
+++ b/datasets/v1-compressed/silesia/samba.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41a7d7d82211282c56c538e78376e8454867eb83cd0b7c1722135b9590d92306
-size 9102594

--- a/datasets/v1-compressed/silesia/sao.tamp
+++ b/datasets/v1-compressed/silesia/sao.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b041d04441550f118ae2e0a179e32a43c8cfe364daa9c5233a316932bb35a62
-size 6137755

--- a/datasets/v1-compressed/silesia/webster.tamp
+++ b/datasets/v1-compressed/silesia/webster.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dec3393e12db417223069da7b77cd458f08f288ee5bf456ea48656a9024674e8
-size 18694172

--- a/datasets/v1-compressed/silesia/x-ray.tamp
+++ b/datasets/v1-compressed/silesia/x-ray.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:933bbf2441f5938a80a6b4817160c86e77f47c48ab84612adceb45d728efdfd5
-size 7510606

--- a/datasets/v1-compressed/silesia/xml.tamp
+++ b/datasets/v1-compressed/silesia/xml.tamp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1340ee234214f06e36b43bd3089d56b29ae9fa31ef945c75d9b23ab67cb89bc6
-size 1681687

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,12 @@ def pytest_addoption(parser):
         "--no-dataset",
         action="store_true",
         default=False,
-        help="Skip dataset regression tests (which require LFS files).",
+        help="Skip dataset regression tests (which require the downloaded corpora).",
     )
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "dataset: mark test as requiring dataset files (use --no-dataset to skip)")
+    config.addinivalue_line("markers", "dataset: mark test as requiring corpus files (use --no-dataset to skip)")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/test_dataset_regression.py
+++ b/tests/test_dataset_regression.py
@@ -4,8 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from tamp._c_compressor import compress as c_compress
-from tamp._c_decompressor import decompress as c_decompress
+try:
+    from tamp._c_compressor import compress as c_compress
+    from tamp._c_decompressor import decompress as c_decompress
+except ImportError:
+    c_compress = None
+    c_decompress = None
 
 PROJECT_DIR = Path(__file__).parent.parent
 
@@ -17,9 +21,10 @@ PROJECT_DIR = Path(__file__).parent.parent
 # bytes hash to the recorded value (format-stability regression), then decompresses
 # and asserts a byte-exact round trip (correctness).
 #
-# The source corpora are fetched with ``make download-enwik8 download-silesia``;
-# the uf2 fixture lives at ``datasets/RPI_PICO-20250415-v1.25.0.uf2``. Tests for a
-# corpus that isn't present locally are skipped (use ``--no-dataset`` to skip all).
+# The source corpora are fetched with
+# ``make download-enwik8 download-silesia download-micropython``; the uf2 fixture
+# lives at ``datasets/RPI_PICO-20250415-v1.25.0.uf2``. Tests for a corpus that isn't
+# present locally are skipped (use ``--no-dataset`` to skip all).
 #
 # To regenerate the ``.tamp`` ground-truth binaries (e.g. for cross-checking against
 # another implementation), see ``make v1-compressed-datasets`` /
@@ -105,9 +110,14 @@ DATASETS = [
 
 
 def _check(rel_path, expected_compressed_sha256, *, extended):
+    if c_compress is None or c_decompress is None:
+        raise unittest.SkipTest("C extensions not built (run `poetry run python build.py build_ext --inplace`)")
+
     source = PROJECT_DIR / rel_path
     if not source.is_file():
-        raise unittest.SkipTest(f"source corpus not found: {rel_path} (run `make download-enwik8 download-silesia`)")
+        raise unittest.SkipTest(
+            f"source corpus not found: {rel_path} (run `make download-enwik8 download-silesia download-micropython`)"
+        )
 
     data = source.read_bytes()
     compressed = c_compress(data, extended=extended)

--- a/tests/test_dataset_regression.py
+++ b/tests/test_dataset_regression.py
@@ -4,166 +4,135 @@ from pathlib import Path
 
 import pytest
 
-PROJECT_DIR = Path(__file__).parent.parent
-
-# Test C implementation (Python implementation is too slow for large datasets)
+from tamp._c_compressor import compress as c_compress
 from tamp._c_decompressor import decompress as c_decompress
 
-DECOMPRESSOR_IMPLEMENTATIONS = [
-    ("C (Cython)", c_decompress),
-]
+PROJECT_DIR = Path(__file__).parent.parent
 
-# Expected SHA256 hashes of the *decompressed* content.
-V1_DATASETS = [
-    (
-        "datasets/v1-compressed/enwik8.tamp",
-        "2b49720ec4d78c3c9fabaee6e4179a5e997302b3a70029f30f2d582218c024a8",
-    ),
-    (
-        "datasets/v1-compressed/RPI_PICO-20250415-v1.25.0.uf2.tamp",
-        "e0c40eacf1afc550a6add74888c48bb981b28788a6d75a62a0e2444e997b9864",
-    ),
-    (
-        "datasets/v1-compressed/silesia/dickens.tamp",
-        "b24c37886142e11d0ee687db6ab06f936207aa7f2ea1fd1d9a36763c7a507e6a",
-    ),
-    (
-        "datasets/v1-compressed/silesia/mozilla.tamp",
-        "657fc3764b0c75ac9de9623125705831ebbfbe08fed248df73bc2dc66e2a963b",
-    ),
-    (
-        "datasets/v1-compressed/silesia/mr.tamp",
-        "68637ed52e3e4860174ed2dc0840ac77d5f1a60abbcb13770d5754e3774d53e6",
-    ),
-    (
-        "datasets/v1-compressed/silesia/nci.tamp",
-        "fc63a31770947b8c2062d3b19ca94c00485a232bb91b502021948fee983e1635",
-    ),
-    (
-        "datasets/v1-compressed/silesia/ooffice.tamp",
-        "e7ee013880d34dd5208283d0d3d91b07f442e067454276095ded14f322a656eb",
-    ),
-    (
-        "datasets/v1-compressed/silesia/osdb.tamp",
-        "60f027179302ca3ad87c58ac90b6be72ec23588aaa7a3b7fe8ecc0f11def3fa3",
-    ),
-    (
-        "datasets/v1-compressed/silesia/reymont.tamp",
-        "0eac0114a3dfe6e2ee1f345a0f79d653cb26c3bc9f0ed79238af4933422b7578",
-    ),
-    (
-        "datasets/v1-compressed/silesia/samba.tamp",
-        "93ba07bc44d8267789c1d911992f40b089ffa2140b4a160fac11ccae9a40e7b2",
-    ),
-    (
-        "datasets/v1-compressed/silesia/sao.tamp",
-        "c2d0ea2cc59d4c21b7fe43a71499342a00cbe530a1d5548770e91ecd6214adcc",
-    ),
-    (
-        "datasets/v1-compressed/silesia/webster.tamp",
-        "6a68f69b26daf09f9dd84f7470368553194a0b294fcfa80f1604efb11143a383",
-    ),
-    (
-        "datasets/v1-compressed/silesia/x-ray.tamp",
-        "7de9fce1405dc44ae5e6813ed21cd5751e761bd4265655a005d39b9685d1c9ad",
-    ),
-    (
-        "datasets/v1-compressed/silesia/xml.tamp",
-        "0e82e54e695c1938e4193448022543845b33020c8be6bf3bf3ead2224903e08c",
-    ),
-]
+# Regression fixtures for the compressed output of known corpora.
+#
+# Rather than committing the (large) ground-truth ``.tamp`` binaries via git LFS,
+# we store only the SHA256 of the compressed output here. Each test compresses
+# the source corpus with the current C implementation and asserts the compressed
+# bytes hash to the recorded value (format-stability regression), then decompresses
+# and asserts a byte-exact round trip (correctness).
+#
+# The source corpora are fetched with ``make download-enwik8 download-silesia``;
+# the uf2 fixture lives at ``datasets/RPI_PICO-20250415-v1.25.0.uf2``. Tests for a
+# corpus that isn't present locally are skipped (use ``--no-dataset`` to skip all).
+#
+# To regenerate the ``.tamp`` ground-truth binaries (e.g. for cross-checking against
+# another implementation), see ``make v1-compressed-datasets`` /
+# ``make extended-compressed-datasets``; the SHA256s below identify the exact files
+# those targets must produce.
+#
+# Compression settings are the library defaults (window=10, literal=8, no lazy
+# matching); only the ``extended`` flag varies between the two formats.
 
-# Extended format datasets (uses RLE and Extended Match encoding)
-EXTENDED_DATASETS = [
+# (source_rel_path, v1_compressed_sha256, extended_compressed_sha256)
+DATASETS = [
     (
-        "datasets/extended-compressed/RPI_PICO-20250415-v1.25.0.uf2.tamp",
-        "e0c40eacf1afc550a6add74888c48bb981b28788a6d75a62a0e2444e997b9864",
+        "datasets/enwik8",
+        "02e05af059a0040d641988075cf1dfc479a084f9a34b5c8a348354211c5fa038",
+        "d9d804c91b4dc5e81856db074760037040421cfa84e1ea211e16dde8c295ce6d",
     ),
     (
-        "datasets/extended-compressed/dickens.tamp",
-        "b24c37886142e11d0ee687db6ab06f936207aa7f2ea1fd1d9a36763c7a507e6a",
+        "datasets/RPI_PICO-20250415-v1.25.0.uf2",
+        "b14029d9171b6fdff493b03db6634cf20d654674fbd68c0ea6e1b321af1a4aad",
+        "94be865699e667ceffb7bae10bc5c040fe6cdc22b9e02e61bd88363d767ec171",
     ),
     (
-        "datasets/extended-compressed/mr.tamp",
-        "68637ed52e3e4860174ed2dc0840ac77d5f1a60abbcb13770d5754e3774d53e6",
+        "datasets/silesia/dickens",
+        "caacd14fc2a6bbf5b8ee13b49f94d1ddab2b8eba8e6379685ee67f6b309f33fd",
+        "01482dc4fa9c7c7674eca711a378d8d1ac7c59615b326a8d9a06f09bc9f33c30",
     ),
     (
-        "datasets/extended-compressed/ooffice.tamp",
-        "e7ee013880d34dd5208283d0d3d91b07f442e067454276095ded14f322a656eb",
+        "datasets/silesia/mozilla",
+        "5a4d69d28071e4327917be293ff4c9cd9c1b362a48d8f15d5693b786622e7343",
+        "53497c04175742c323b7e086a4f0ce44533c8f238ef85562591c79a587a81679",
     ),
     (
-        "datasets/extended-compressed/osdb.tamp",
-        "60f027179302ca3ad87c58ac90b6be72ec23588aaa7a3b7fe8ecc0f11def3fa3",
+        "datasets/silesia/mr",
+        "7862014d14955b765959ddc875f00f36401b49654e75a564f9313b9ac04c35dd",
+        "94f27dfffe842fff3669e80eb5a3c769c33cd591f08001ae5e2eb95ff152a1fc",
     ),
     (
-        "datasets/extended-compressed/reymont.tamp",
-        "0eac0114a3dfe6e2ee1f345a0f79d653cb26c3bc9f0ed79238af4933422b7578",
+        "datasets/silesia/nci",
+        "cb20a8e688046e36d123d2528c16c12dfa75e6cb1ae6e7bbf7d634f80ea7ae07",
+        "0acbb7c787947df92ab4a44d4259f52d327d98dd2ec5860a998c51ed32409753",
     ),
     (
-        "datasets/extended-compressed/sao.tamp",
-        "c2d0ea2cc59d4c21b7fe43a71499342a00cbe530a1d5548770e91ecd6214adcc",
+        "datasets/silesia/ooffice",
+        "8d7c35aae8fc664d89350fbf6162db34151f7ef85175c555d4c366f23ecd2b80",
+        "ae3bcd7bbff8f223a2c4ca937a5e2eafd793c8abda48d203ed110e98f2896526",
     ),
     (
-        "datasets/extended-compressed/x-ray.tamp",
-        "7de9fce1405dc44ae5e6813ed21cd5751e761bd4265655a005d39b9685d1c9ad",
+        "datasets/silesia/osdb",
+        "2e28f5f7cb1173a288cdaadfedb3a554ed50af3bb297fe029964876d7345d69b",
+        "1eb802368db32844da9c195095cb6727f0c39f719325ac23c446cee2de1d557d",
     ),
     (
-        "datasets/extended-compressed/xml.tamp",
-        "0e82e54e695c1938e4193448022543845b33020c8be6bf3bf3ead2224903e08c",
+        "datasets/silesia/reymont",
+        "f81ae5f8ae000a3ba898efea3c4b303628fe2d3d432f8913f07d5feac9274e3f",
+        "4024c6820a3af628dd2059c9261b2713c9a8f48b4a26e57c45a9776fec9b8068",
     ),
     (
-        "datasets/extended-compressed/samba.tamp",
-        "93ba07bc44d8267789c1d911992f40b089ffa2140b4a160fac11ccae9a40e7b2",
+        "datasets/silesia/samba",
+        "41a7d7d82211282c56c538e78376e8454867eb83cd0b7c1722135b9590d92306",
+        "f13c7e856a8e0366b7c2fa58de56bde427bf1840335e596a70db46a6aff4feec",
     ),
     (
-        "datasets/extended-compressed/nci.tamp",
-        "fc63a31770947b8c2062d3b19ca94c00485a232bb91b502021948fee983e1635",
+        "datasets/silesia/sao",
+        "3b041d04441550f118ae2e0a179e32a43c8cfe364daa9c5233a316932bb35a62",
+        "8c05ac1c7d78b04874f07e10265cd254ecf9d6dcf1a3f0d1ea695815509ff0b1",
     ),
     (
-        "datasets/extended-compressed/webster.tamp",
-        "6a68f69b26daf09f9dd84f7470368553194a0b294fcfa80f1604efb11143a383",
+        "datasets/silesia/webster",
+        "dec3393e12db417223069da7b77cd458f08f288ee5bf456ea48656a9024674e8",
+        "91d3c9ddb94e370d4f9cb518e846fda8a197bd9ef4ea4fcb91f84688af49316a",
     ),
     (
-        "datasets/extended-compressed/mozilla.tamp",
-        "657fc3764b0c75ac9de9623125705831ebbfbe08fed248df73bc2dc66e2a963b",
+        "datasets/silesia/x-ray",
+        "933bbf2441f5938a80a6b4817160c86e77f47c48ab84612adceb45d728efdfd5",
+        "4ba0c1fb79addae24888c12a466e84b73c32ca608836c458487226d224a63fc3",
     ),
     (
-        "datasets/extended-compressed/enwik8.tamp",
-        "2b49720ec4d78c3c9fabaee6e4179a5e997302b3a70029f30f2d582218c024a8",
+        "datasets/silesia/xml",
+        "1340ee234214f06e36b43bd3089d56b29ae9fa31ef945c75d9b23ab67cb89bc6",
+        "11a9d7e077f31a83b06cbcfb95c6ef2d74355e6f6af9decba3c2e3529e1e903f",
     ),
 ]
 
 
-class TestV1Decompression(unittest.TestCase):
+def _check(rel_path, expected_compressed_sha256, *, extended):
+    source = PROJECT_DIR / rel_path
+    if not source.is_file():
+        raise unittest.SkipTest(f"source corpus not found: {rel_path} (run `make download-enwik8 download-silesia`)")
+
+    data = source.read_bytes()
+    compressed = c_compress(data, extended=extended)
+
+    actual = hashlib.sha256(compressed).hexdigest()
+    assert actual == expected_compressed_sha256, f"compressed SHA256 mismatch for {rel_path} (extended={extended})"
+
+    # Round-trip: the compressed stream must decompress back to the original bytes.
+    assert c_decompress(compressed) == data, f"round-trip mismatch for {rel_path} (extended={extended})"
+
+
+class TestV1Compression(unittest.TestCase):
     @pytest.mark.dataset
-    def test_v1_decompress(self):
-        for impl_name, decompress_func in DECOMPRESSOR_IMPLEMENTATIONS:
-            for rel_path, expected_sha256 in V1_DATASETS:
-                with self.subTest(implementation=impl_name, dataset=rel_path):
-                    path = PROJECT_DIR / rel_path
-
-                    with open(path, "rb") as f:
-                        data = f.read()
-
-                    decompressed = decompress_func(data)
-                    actual = hashlib.sha256(decompressed).hexdigest()
-                    self.assertEqual(actual, expected_sha256, f"SHA256 mismatch for {rel_path} using {impl_name}")
+    def test_v1_compress(self):
+        for rel_path, v1_sha256, _ in DATASETS:
+            with self.subTest(dataset=rel_path):
+                _check(rel_path, v1_sha256, extended=False)
 
 
-class TestExtendedDecompression(unittest.TestCase):
+class TestExtendedCompression(unittest.TestCase):
     @pytest.mark.dataset
-    def test_extended_decompress(self):
-        for impl_name, decompress_func in DECOMPRESSOR_IMPLEMENTATIONS:
-            for rel_path, expected_sha256 in EXTENDED_DATASETS:
-                with self.subTest(implementation=impl_name, dataset=rel_path):
-                    path = PROJECT_DIR / rel_path
-
-                    with open(path, "rb") as f:
-                        data = f.read()
-
-                    decompressed = decompress_func(data)
-                    actual = hashlib.sha256(decompressed).hexdigest()
-                    self.assertEqual(actual, expected_sha256, f"SHA256 mismatch for {rel_path} using {impl_name}")
+    def test_extended_compress(self):
+        for rel_path, _, extended_sha256 in DATASETS:
+            with self.subTest(dataset=rel_path):
+                _check(rel_path, extended_sha256, extended=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The decompression regression test relied on ~914MB of compressed .tamp artifacts stored in git LFS, which is costly. Replace them with the SHA256 of each compressed artifact recorded directly in the test, and re-derive the artifacts by compressing the source corpora with the current implementation.

- tests/test_dataset_regression.py: compress enwik8/silesia/uf2 with the C implementation (v1 = --no-extended, extended = default), assert the compressed output hashes match the recorded values, then assert a byte-exact round trip. Per-dataset skip when the source corpus is absent.
- .gitattributes removed; .gitignore no longer un-ignores the compressed dirs so regenerated binaries can't be re-committed.
- git rm the 28 LFS artifacts.
- Makefile: fix v1-compressed-datasets (was using default --extended) and add extended-compressed-datasets; both documented as the local rederivation path.
- CI: drop the cache-lfs job and LFS pulls; matrix tests run --no-dataset; add a dedicated dataset-regression job. Add a fetch-corpora prefetch job that downloads + caches the corpora once, with dataset-regression and integrity-enwik8 restoring from it to avoid re-hitting upstream hosts.